### PR TITLE
feat: add small `generic-service-metrics` and `ingress-nginx-loki` fixes to work with new grafana

### DIFF
--- a/general/generic-service-metrics.json
+++ b/general/generic-service-metrics.json
@@ -915,17 +915,6 @@
             "format": "heatmap",
             "legendFormat": "{{le}}",
             "refId": "A"
-        },
-        {
-            "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-            },
-            "exemplar": false,
-            "expr": "sum(increase(istio_request_duration_milliseconds_bucket{destination_service_namespace=\"$namespace\",destination_service_name=\"$service\",reporter=\"source\"}[$__rate_interval])) by (le)",
-            "format": "heatmap",
-            "legendFormat": "{{le}}",
-            "refId": "B"
         }
         ],
         "title": "Response times",

--- a/kubernetes/nginx-controller/ingress-nginx-loki.yaml
+++ b/kubernetes/nginx-controller/ingress-nginx-loki.yaml
@@ -217,7 +217,7 @@
       "pluginVersion": "8.1.2",
       "targets": [
         {
-          "expr": "bytes_over_time({job=~\"$job\", instance=~\"$instance\"}[$__interval])",
+          "expr": "sum by (app) (bytes_over_time({job=~\"$job\", instance=~\"$instance\"}[$__interval]))",
           "instant": true,
           "legendFormat": "$label_value",
           "range": false,
@@ -467,7 +467,7 @@
       "pluginVersion": "8.1.2",
       "targets": [
         {
-          "expr": "count_over_time({job=~\"$job\", instance=~\"$instance\"}[$__interval])",
+          "expr": "sum by (app) (count_over_time({job=~\"$job\", instance=~\"$instance\"}[$__interval]))",
           "instant": true,
           "range": false,
           "refId": "A"


### PR DESCRIPTION
These are changes needed for updated Grafana and Loki: https://saritasa.atlassian.net/browse/CGSLA-22
Original PR: https://github.com/saritasa-nest/crossingguard-kubernetes-aws/pull/19