### PR TITLE
fix: edit argocd dashboard configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2023-12-18
+
+[prod]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-grafana-dashboards/pull/5)
+- Fixed ArgoCD dashboard configuration
+
 ## 2023-11-23
 
 [prod]

--- a/kubernetes/argocd/argocd.json
+++ b/kubernetes/argocd/argocd.json
@@ -26,7 +26,7 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 14584,
   "graphTooltip": 0,
-  "iteration": 1660554059535,
+  "id": 4,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -59,10 +59,15 @@
       "id": 26,
       "links": [],
       "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
         "content": "![argoimage](https://avatars1.githubusercontent.com/u/30269780?s=110&v=4)",
         "mode": "markdown"
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "transparent": true,
       "type": "text"
     },
@@ -112,9 +117,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -192,9 +198,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "repeatDirection": "h",
       "targets": [
         {
@@ -258,9 +265,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "repeatDirection": "h",
       "targets": [
         {
@@ -331,9 +339,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -399,9 +408,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -469,7 +479,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -590,7 +600,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -696,7 +706,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -745,7 +755,7 @@
       }
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "datasource": {
         "uid": "$datasource"
       },
@@ -756,216 +766,215 @@
         "y": 12
       },
       "id": 104,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 13
-          },
-          "hiddenSeries": false,
-          "id": 56,
-          "interval": "",
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": true,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sort": "total",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "paceLength": 10,
-          "percentage": false,
-          "pluginVersion": "8.1.2",
-          "pointradius": 1,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(round(increase(argocd_app_sync_total{namespace=~\"$namespace\",dest_server=~\"$cluster\"}[$interval]))) by ($grouping)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{$grouping}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Sync Activity",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:227",
-              "decimals": 0,
-              "format": "short",
-              "label": "",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:228",
-              "decimals": -12,
-              "format": "short",
-              "label": "",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 5,
-            "w": 24,
-            "x": 0,
-            "y": 19
-          },
-          "hiddenSeries": false,
-          "id": 73,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": false,
-            "max": true,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sort": "total",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "paceLength": 10,
-          "percentage": false,
-          "pluginVersion": "8.1.2",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(round(increase(argocd_app_sync_total{namespace=~\"$namespace\",phase=~\"Error|Failed\",dest_server=~\"$cluster\"}[$interval]))) by ($grouping, phase)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{phase}}: {{$grouping}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Sync Failures",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 0,
-              "format": "none",
-              "label": "",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": "",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
+      "panels": [],
       "title": "Sync Stats",
       "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "hiddenSeries": false,
+      "id": 56,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "total",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "paceLength": 10,
+      "percentage": false,
+      "pluginVersion": "10.2.2",
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(round(increase(argocd_app_sync_total{namespace=~\"$namespace\",dest_server=~\"$cluster\"}[$interval]))) by ($grouping)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{$grouping}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Sync Activity",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:227",
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:228",
+          "decimals": -12,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "hiddenSeries": false,
+      "id": 73,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": false,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "total",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "paceLength": 10,
+      "percentage": false,
+      "pluginVersion": "10.2.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(round(increase(argocd_app_sync_total{namespace=~\"$namespace\",phase=~\"Error|Failed\",dest_server=~\"$cluster\"}[$interval]))) by ($grouping, phase)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{phase}}: {{$grouping}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Sync Failures",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
     },
     {
       "collapsed": false,
@@ -976,7 +985,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 24
       },
       "id": 64,
       "panels": [],
@@ -1003,7 +1012,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 25
       },
       "hiddenSeries": false,
       "id": 58,
@@ -1029,7 +1038,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1091,11 +1100,26 @@
       "datasource": {
         "uid": "$datasource"
       },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 31
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -1105,6 +1129,46 @@
         "show": true
       },
       "links": [],
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {
+          "decimals": 0
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "#b4ff00",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "10.2.2",
       "reverseYBuckets": false,
       "targets": [
         {
@@ -1155,7 +1219,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 38
       },
       "hiddenSeries": false,
       "id": 80,
@@ -1183,7 +1247,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1253,7 +1317,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 33
+        "y": 44
       },
       "hiddenSeries": false,
       "id": 117,
@@ -1276,7 +1340,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1352,7 +1416,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 33
+        "y": 44
       },
       "hiddenSeries": false,
       "id": 98,
@@ -1375,7 +1439,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1435,7 +1499,7 @@
       }
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "datasource": {
         "uid": "$datasource"
       },
@@ -1443,598 +1507,318 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 51
       },
       "id": 102,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 9
-          },
-          "hiddenSeries": false,
-          "id": 34,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "connected",
-          "options": {
-            "alertThreshold": true
-          },
-          "paceLength": 10,
-          "percentage": false,
-          "pluginVersion": "8.1.2",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "go_memstats_heap_alloc_bytes{kubernetes_name=\"argo-cd-argocd-application-controller-metrics\",kubernetes_namespace=~\"$namespace\"}",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{kubernetes_name}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Memory Usage",
-          "tooltip": {
-            "shared": false,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "line+area"
-                }
-              },
-              "decimals": 1,
-              "links": [],
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "transparent"
-                  },
-                  {
-                    "color": "red",
-                    "value": 70
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 16
-          },
-          "id": 108,
-          "links": [],
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean",
-                "lastNotNull",
-                "max"
-              ],
-              "displayMode": "table",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "8.1.2",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "rate(container_cpu_usage_seconds_total{image!=\"\", container!=\"POD\", namespace=~\"$namespace\", pod=~\".+application-controller.+\"}[5m])* 100",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "CPU Usage (5m)",
-          "type": "timeseries"
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 23
-          },
-          "hiddenSeries": false,
-          "id": 62,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": true,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "paceLength": 10,
-          "percentage": false,
-          "pluginVersion": "8.1.2",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "go_goroutines{kubernetes_namespace=~\"$namespace\", kubernetes_name=\"argo-cd-argocd-application-controller-metrics\"}",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{kubernetes_name}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Goroutines",
-          "tooltip": {
-            "shared": false,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
+      "panels": [],
       "title": "Controller Telemetry",
       "type": "row"
     },
     {
-      "collapsed": true,
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "hiddenSeries": false,
+      "id": 34,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "paceLength": 10,
+      "percentage": false,
+      "pluginVersion": "10.2.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "go_memstats_heap_alloc_bytes{container=\"application-controller\",namespace=~\"$namespace\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Memory Usage",
+      "tooltip": {
+        "shared": false,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
       "datasource": {
         "uid": "$datasource"
       },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "decimals": 1,
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 70
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
       "gridPos": {
-        "h": 1,
+        "h": 7,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 59
       },
-      "id": 88,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 10
-          },
-          "hiddenSeries": false,
-          "id": 90,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.1.2",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(argocd_cluster_api_resource_objects{kubernetes_namespace=~\"$namespace\",server=~\"$cluster\"}) by (server)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{server}}",
-              "refId": "A"
-            }
+      "id": 108,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
           ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Resource Objects Count",
-          "tooltip": {
-            "shared": false,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.1.2",
+      "targets": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 17
-          },
-          "hiddenSeries": false,
-          "id": 92,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideEmpty": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.1.2",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "  sum(argocd_cluster_api_resources{kubernetes_namespace=~\"$namespace\",server=~\"$cluster\"}) by (server)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{server}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "API Resources Count",
-          "tooltip": {
-            "shared": false,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 23
-          },
-          "hiddenSeries": false,
-          "id": 86,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.1.2",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(increase(argocd_cluster_events_total{kubernetes_namespace=~\"$namespace\",server=~\"$cluster\"}[$interval])) by (server)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{server}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Cluster Events Count",
-          "tooltip": {
-            "shared": false,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "exemplar": true,
+          "expr": "rate(container_cpu_usage_seconds_total{image!=\"\", container!=\"POD\", namespace=~\"$namespace\", pod=~\".+application-controller.+\"}[5m])* 100",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
         }
       ],
-      "title": "Cluster Stats",
-      "type": "row"
+      "title": "CPU Usage (5m)",
+      "type": "timeseries"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "hiddenSeries": false,
+      "id": 62,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "paceLength": 10,
+      "percentage": false,
+      "pluginVersion": "10.2.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "go_goroutines{namespace=~\"$namespace\", container=\"application-controller\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{container}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Goroutines",
+      "tooltip": {
+        "shared": false,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
     },
     {
       "collapsed": false,
@@ -2045,7 +1829,327 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 73
+      },
+      "id": 88,
+      "panels": [],
+      "title": "Cluster Stats",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 74
+      },
+      "hiddenSeries": false,
+      "id": 90,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.2.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(argocd_cluster_api_resource_objects{namespace=~\"$namespace\",server=~\"$cluster\"}) by (server)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{server}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Resource Objects Count",
+      "tooltip": {
+        "shared": false,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 81
+      },
+      "hiddenSeries": false,
+      "id": 92,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.2.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "  sum(argocd_cluster_api_resources{namespace=~\"$namespace\",server=~\"$cluster\"}) by (server)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{server}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "API Resources Count",
+      "tooltip": {
+        "shared": false,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 87
+      },
+      "hiddenSeries": false,
+      "id": 86,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.2.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(increase(argocd_cluster_events_total{namespace=~\"$namespace\",server=~\"$cluster\"}[$interval])) by (server)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{server}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Cluster Events Count",
+      "tooltip": {
+        "shared": false,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 94
       },
       "id": 70,
       "panels": [],
@@ -2073,7 +2177,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 95
       },
       "hiddenSeries": false,
       "id": 82,
@@ -2095,7 +2199,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2169,7 +2273,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 43
+        "y": 95
       },
       "hiddenSeries": false,
       "id": 84,
@@ -2191,7 +2295,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2259,11 +2363,26 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 51
+        "y": 103
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -2272,6 +2391,44 @@
       "legend": {
         "show": false
       },
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#b4ff00",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Warm",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": false
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "10.2.2",
       "reverseYBuckets": false,
       "targets": [
         {
@@ -2318,11 +2475,26 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 51
+        "y": 103
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -2331,6 +2503,44 @@
       "legend": {
         "show": false
       },
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#b4ff00",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Warm",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": false
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "10.2.2",
       "reverseYBuckets": false,
       "targets": [
         {
@@ -2384,7 +2594,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 111
       },
       "hiddenSeries": false,
       "id": 71,
@@ -2407,7 +2617,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2423,11 +2633,11 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "go_memstats_heap_alloc_bytes{app_kubernetes_io_instance=\"argo-cd\", namespace=~\"$namespace\"}",
+          "expr": "go_memstats_heap_alloc_bytes{container=\"repo-server\", namespace=~\"$namespace\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{app_kubernetes_io_component}}",
+          "legendFormat": "{{container}}",
           "range": true,
           "refId": "A"
         }
@@ -2472,6 +2682,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -2483,6 +2696,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineStyle": {
               "fill": "solid"
@@ -2508,7 +2722,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2524,7 +2739,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 119
       },
       "id": 118,
       "links": [],
@@ -2537,7 +2752,8 @@
             "min"
           ],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -2580,7 +2796,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 75
+        "y": 127
       },
       "hiddenSeries": false,
       "id": 72,
@@ -2602,7 +2818,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2618,11 +2834,11 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "go_goroutines{namespace=~\"$namespace\", app_kubernetes_io_instance=\"argo-cd\"}",
+          "expr": "go_goroutines{namespace=~\"$namespace\", container=\"repo-server\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{app_kubernetes_io_component}}",
+          "legendFormat": "{{container}}",
           "range": true,
           "refId": "A"
         }
@@ -2666,7 +2882,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 82
+        "y": 134
       },
       "id": 66,
       "panels": [],
@@ -2688,7 +2904,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 83
+        "y": 135
       },
       "hiddenSeries": false,
       "id": 61,
@@ -2710,7 +2926,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2726,7 +2942,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "go_memstats_heap_alloc_bytes{app_kubernetes_io_name=\"argocd-server-metrics\", namespace=~\"$namespace\"}",
+          "expr": "go_memstats_heap_alloc_bytes{container=\"server\", namespace=~\"$namespace\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2781,7 +2997,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 91
+        "y": 143
       },
       "hiddenSeries": false,
       "id": 36,
@@ -2803,7 +3019,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2819,7 +3035,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "go_goroutines{namespace=~\"$namespace\", app_kubernetes_io_name=\"argocd-server-metrics\"}",
+          "expr": "go_goroutines{namespace=~\"$namespace\", container=\"server\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2869,6 +3085,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -2880,6 +3099,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -2901,7 +3121,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2917,7 +3138,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 100
+        "y": 152
       },
       "id": 38,
       "links": [],
@@ -2925,7 +3146,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -2941,11 +3163,11 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "go_gc_duration_seconds{app_kubernetes_io_name=\"argocd-server-metrics\", quantile=\"1\", namespace=~\"$namespace\"}",
+          "expr": "go_gc_duration_seconds{container=\"server\", quantile=\"1\", namespace=~\"$namespace\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{app_kubernetes_io_component}}",
+          "legendFormat": "{{container}}",
           "range": true,
           "refId": "A"
         }
@@ -2958,15 +3180,20 @@
         "h": 2,
         "w": 24,
         "x": 0,
-        "y": 109
+        "y": 161
       },
       "id": 54,
       "links": [],
       "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
         "content": "#### gRPC Services:",
         "mode": "markdown"
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "transparent": true,
       "type": "text"
     },
@@ -2981,6 +3208,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -2992,6 +3222,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -3013,7 +3244,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3029,7 +3261,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 111
+        "y": 163
       },
       "id": 40,
       "links": [],
@@ -3041,7 +3273,10 @@
             "sum"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
         },
         "tooltip": {
           "mode": "single",
@@ -3055,12 +3290,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(grpc_server_handled_total{ app_kubernetes_io_name=\"argocd-server-metrics\", job=\"kubernetes-service-endpoints\",grpc_service=\"application.ApplicationService\", namespace=~\"$namespace\"}[$interval])) by (grpc_code, grpc_method)",
+          "expr": "sort_desc(sum(increase(grpc_server_handled_total{namespace=~\"$namespace\", grpc_service=\"application.ApplicationService\"}[$interval])) by (grpc_code, grpc_method))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{grpc_code}},{{grpc_method}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -3078,6 +3315,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -3089,6 +3329,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -3110,7 +3351,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3126,7 +3368,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 111
+        "y": 163
       },
       "id": 42,
       "links": [],
@@ -3138,7 +3380,8 @@
             "sum"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -3152,12 +3395,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(grpc_server_handled_total{app_kubernetes_io_name=\"argocd-server-metrics\", job=\"kubernetes-service-endpoints\", namespace=~\"$namespace\", grpc_service=\"cluster.ClusterService\"}[$interval])) by (grpc_code, grpc_method)",
+          "expr": "sort_desc(sum(increase(grpc_server_handled_total{namespace=~\"$namespace\", grpc_service=\"cluster.ClusterService\"}[$interval])) by (grpc_code, grpc_method))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{grpc_code}},{{grpc_method}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -3175,6 +3420,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -3186,6 +3434,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -3207,7 +3456,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3223,7 +3473,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 120
+        "y": 172
       },
       "id": 44,
       "links": [],
@@ -3235,7 +3485,8 @@
             "sum"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -3249,12 +3500,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(grpc_server_handled_total{app_kubernetes_io_name=\"argocd-server-metrics\", job=\"kubernetes-service-endpoints\",namespace=~\"$namespace\",grpc_service=\"project.ProjectService\"}[$interval])) by (grpc_code, grpc_method)",
+          "expr": "sort_desc(sum(increase(grpc_server_handled_total{namespace=~\"$namespace\",grpc_service=\"project.ProjectService\"}[$interval])) by (grpc_code, grpc_method))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{grpc_code}},{{grpc_method}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -3272,6 +3525,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -3283,6 +3539,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -3304,7 +3561,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3320,7 +3578,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 120
+        "y": 172
       },
       "id": 46,
       "links": [],
@@ -3332,7 +3590,8 @@
             "sum"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -3346,12 +3605,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(grpc_server_handled_total{app_kubernetes_io_name=\"argocd-server-metrics\", job=\"kubernetes-service-endpoints\", namespace=~\"$namespace\", grpc_service=\"repository.RepositoryService\"}[$interval])) by (grpc_code, grpc_method)",
+          "expr": "sort_desc(sum(increase(grpc_server_handled_total{namespace=~\"$namespace\", grpc_service=\"repository.RepositoryService\"}[$interval])) by (grpc_code, grpc_method))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{grpc_code}},{{grpc_method}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -3369,6 +3630,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -3380,6 +3644,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -3401,7 +3666,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3417,7 +3683,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 129
+        "y": 181
       },
       "id": 48,
       "links": [],
@@ -3429,7 +3695,8 @@
             "sum"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -3443,12 +3710,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(grpc_server_handled_total{app_kubernetes_io_name=\"argocd-server-metrics\", job=\"kubernetes-service-endpoints\",namespace=~\"$namespace\", grpc_service=\"session.SessionService\"}[$interval])) by (grpc_code, grpc_method)",
+          "expr": "sort_desc(sum(increase(grpc_server_handled_total{namespace=~\"$namespace\", grpc_service=\"session.SessionService\"}[$interval])) by (grpc_code, grpc_method))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{grpc_code}},{{grpc_method}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -3470,7 +3739,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 129
+        "y": 181
       },
       "hiddenSeries": false,
       "id": 49,
@@ -3495,7 +3764,7 @@
       },
       "paceLength": 10,
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3509,12 +3778,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(grpc_server_handled_total{app_kubernetes_io_name=\"argocd-server-metrics\", job=\"kubernetes-service-endpoints\", namespace=~\"$namespace\",grpc_service=\"version.VersionService\"}[$interval])) by (grpc_code, grpc_method)",
+          "expr": "sort_desc(sum(increase(grpc_server_handled_total{namespace=~\"$namespace\",grpc_service=\"version.VersionService\"}[$interval])) by (grpc_code, grpc_method))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{grpc_code}},{{grpc_method}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -3559,6 +3830,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -3570,6 +3844,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -3591,7 +3866,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3607,7 +3883,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 138
+        "y": 190
       },
       "id": 50,
       "links": [],
@@ -3619,7 +3895,8 @@
             "sum"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -3633,12 +3910,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(grpc_server_handled_total{app_kubernetes_io_name=\"argocd-server-metrics\", job=\"kubernetes-service-endpoints\",namespace=~\"$namespace\",grpc_service=\"account.AccountService\"}[$interval])) by (grpc_code, grpc_method)",
+          "expr": "sort_desc(sum(increase(grpc_server_handled_total{namespace=~\"$namespace\",grpc_service=\"account.AccountService\"}[$interval])) by (grpc_code, grpc_method))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{grpc_code}},{{grpc_method}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -3656,6 +3935,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -3667,6 +3949,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -3688,7 +3971,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3704,7 +3988,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 138
+        "y": 190
       },
       "id": 99,
       "links": [],
@@ -3716,7 +4000,8 @@
             "sum"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -3730,12 +4015,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(grpc_server_handled_total{app_kubernetes_io_name=\"argocd-server-metrics\", job=\"kubernetes-service-endpoints\",namespace=~\"$namespace\", grpc_service=\"cluster.SettingsService\"}[$interval])) by (grpc_code, grpc_method)",
+          "expr": "sort_desc(sum(increase(grpc_server_handled_total{namespace=~\"$namespace\", grpc_service=\"cluster.SettingsService\"}[$interval])) by (grpc_code, grpc_method))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{grpc_code}},{{grpc_method}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -3743,7 +4030,7 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -3752,141 +4039,148 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 147
+        "y": 199
       },
       "id": 110,
-      "panels": [
+      "panels": [],
+      "title": "Redis Stats",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 200
+      },
+      "hiddenSeries": false,
+      "id": 112,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.2.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 148
-          },
-          "hiddenSeries": false,
-          "id": 112,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.5.3",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "exemplar": true,
-              "expr": "sum(increase(argocd_redis_request_total{namespace=~\"$namespace\"}[$interval])) by (failed)",
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Requests by result",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "datasource": {
-            "uid": "${log_source}"
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 24,
-            "x": 0,
-            "y": 155
-          },
-          "id": 120,
-          "options": {
-            "dedupStrategy": "none",
-            "enableLogDetails": true,
-            "prettifyLogMessage": false,
-            "showCommonLabels": false,
-            "showLabels": false,
-            "showTime": false,
-            "sortOrder": "Ascending",
-            "wrapLogMessage": false
-          },
-          "pluginVersion": "8.1.2",
-          "targets": [
-            {
-              "expr": "{namespace=\"argo-cd\"} |=\"OutOfSync\" | logfmt | line_format \"{{ .time }}\\t{{ .reason }}  {{ printf \\\"%-20.20s\\\" .application }}\\t{{ .msg }}\\t{{ .dest_server }}\"",
-              "refId": "A"
-            }
-          ],
-          "title": "OutOfSync (Loki)",
-          "type": "logs"
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(increase(argocd_redis_request_total{namespace=~\"$namespace\"}[$interval])) by (failed)",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
         }
       ],
-      "title": "Redis Stats",
-      "type": "row"
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Requests by result",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${log_source}"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 207
+      },
+      "id": 120,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Ascending",
+        "wrapLogMessage": false
+      },
+      "pluginVersion": "8.1.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "{namespace=\"argo-cd\"} |=\"OutOfSync\" | logfmt | line_format \"{{ .time }}\\t{{ .reason }}  {{ printf \\\"%-20.20s\\\" .application }}\\t{{ .msg }}\\t{{ .dest_server }}\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "OutOfSync (Loki)",
+      "type": "logs"
     }
   ],
   "refresh": "",
-  "schemaVersion": 36,
-  "style": "dark",
+  "schemaVersion": 38,
   "tags": [],
   "templating": {
     "list": [
@@ -3894,7 +4188,7 @@
         "current": {
           "selected": false,
           "text": "Prometheus",
-          "value": "Prometheus"
+          "value": "prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -4005,7 +4299,7 @@
       {
         "allValue": "",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "name",
           "value": "name"
         },
@@ -4068,7 +4362,7 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -4121,7 +4415,7 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -4160,7 +4454,7 @@
         "current": {
           "selected": false,
           "text": "Loki",
-          "value": "Loki"
+          "value": "loki"
         },
         "hide": 0,
         "includeAll": false,
@@ -4177,7 +4471,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {
@@ -4208,6 +4502,6 @@
   "timezone": "",
   "title": "ArgoCD",
   "uid": "DRRqkYOnz",
-  "version": 2,
+  "version": 11,
   "weekStart": ""
 }

--- a/kubernetes/argocd/argocd.json
+++ b/kubernetes/argocd/argocd.json
@@ -4471,7 +4471,7 @@
     ]
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {
@@ -4502,6 +4502,6 @@
   "timezone": "",
   "title": "ArgoCD",
   "uid": "DRRqkYOnz",
-  "version": 11,
+  "version": 12,
   "weekStart": ""
 }

--- a/kubernetes/argocd/argocd.json
+++ b/kubernetes/argocd/argocd.json
@@ -127,12 +127,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "time() - max(process_start_time_seconds{app_kubernetes_io_instance=\"argo-cd\", namespace=\"$namespace\"})",
+          "expr": "time() - max(process_start_time_seconds{service=~\"argocd.*\", namespace=\"$namespace\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -1664,8 +1666,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
-                "value": null
+                "color": "transparent"
               },
               {
                 "color": "red",
@@ -2722,8 +2723,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3121,8 +3121,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3244,8 +3243,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3351,8 +3349,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3456,8 +3453,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3561,8 +3557,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3666,8 +3661,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3866,8 +3860,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3971,8 +3964,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -4471,7 +4463,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {
@@ -4502,6 +4494,6 @@
   "timezone": "",
   "title": "ArgoCD",
   "uid": "DRRqkYOnz",
-  "version": 12,
+  "version": 17,
   "weekStart": ""
 }


### PR DESCRIPTION
### Summary

JIRA: <https://saritasa.atlassian.net/browse/USAWS-20>

Fixed [ArgoCD grafana dashboard](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1>) configuration.

i edited url for ArgoCD dashboard:
<https://github.com/saritasa-nest/usummit-kubernetes-aws/blob/feature/fix-grafana-dashboards/config/addons/monitoring/prometheus/values.yaml#L326>

Edited:
- [Uptime](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-3h&to=now&editPanel=32>)
```bash
time() - max(process_start_time_seconds{app_kubernetes_io_instance="argo-cd", namespace="$namespace"})
```
to
```bash
time() - max(process_start_time_seconds{service=~"argocd.*", namespace="$namespace"})
```
- [Controller Telemetry - Memory usage](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=34>)
```
go_memstats_heap_alloc_bytes{kubernetes_name="argo-cd-argocd-application-controller-metrics",kubernetes_namespace=~"$namespace"}
```
to
```
go_memstats_heap_alloc_bytes{container="application-controller",namespace=~"$namespace"}
```
- [Controller Telemetry - Goroutines](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=62>)
```
go_goroutines{kubernetes_namespace=~"$namespace", kubernetes_name="argo-cd-argocd-application-controller-metrics"}
```
to
```
go_goroutines{namespace=~"$namespace", container="application-controller"}
```
- [Cluster Stats - Resource Objects Count](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=90>)
```
sum(argocd_cluster_api_resource_objects{kubernetes_namespace=~"$namespace",server=~"$cluster"}) by (server)
```
to
```
sum(argocd_cluster_api_resource_objects{namespace=~"$namespace",server=~"$cluster"}) by (server)
```
- [Cluster Stats - API Resources Count](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=92>)
```
sum(argocd_cluster_api_resources{kubernetes_namespace=~"$namespace",server=~"$cluster"}) by (server)
```
to
```
sum(argocd_cluster_api_resources{namespace=~"$namespace",server=~"$cluster"}) by (server)
```
- [Cluster Stats - Cluster Events Count](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=86>)
```
sum(increase(argocd_cluster_events_total{kubernetes_namespace=~"$namespace",server=~"$cluster"}[$interval])) by (server)
```
to
```
sum(increase(argocd_cluster_events_total{namespace=~"$namespace",server=~"$cluster"}[$interval])) by (server)
```
- [Repo Server Stats - Memory Used](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=71>)
```
go_memstats_heap_alloc_bytes{app_kubernetes_io_instance="argo-cd", namespace=~"$namespace"}
```
to
```
go_memstats_heap_alloc_bytes{container="repo-server",  #namespace=~"$namespace"}
```
- [Repo Server Stats - Goroutines](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=72>)
```
go_goroutines{namespace=~"$namespace", app_kubernetes_io_instance="argo-cd"}
```
to
```
go_goroutines{namespace=~"$namespace", container="repo-server"}
```
- [Server Stats - Memory Used](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=61>)
```
go_memstats_heap_alloc_bytes{app_kubernetes_io_name="argocd-server-metrics", namespace=~"$namespace"}
```
to
```
go_memstats_heap_alloc_bytes{container="server", namespace=~"$namespace"}
```
- [Server Stats - Goroutines](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=36>)
```
go_goroutines{namespace=~"$namespace", app_kubernetes_io_name="argocd-server-metrics"}
```
to
```
go_goroutines{namespace=~"$namespace", container="server"}
```
- [Server Stats - GC Time Quantiles](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=38>)
```
go_gc_duration_seconds{app_kubernetes_io_name="argocd-server-metrics", quantile="1", namespace=~"$namespace"}
```
to
```
go_gc_duration_seconds{container="server", quantile="1", namespace=~"$namespace"}
```
- [gRPC Services - ApplicationService Requests](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=40>)
```
sum(increase(grpc_server_handled_total{ app_kubernetes_io_name="argocd-server-metrics", 
job="kubernetes-service-endpoints",grpc_service="application.ApplicationService", 
namespace=~"$namespace"}[$interval])) by (grpc_code, grpc_method)
```
to
```
sort_desc(sum(increase(grpc_server_handled_total{namespace=~"$namespace",
grpc_service="application.ApplicationService"}[$interval])) by (grpc_code, grpc_method))
```
- [gRPC Services - ClusterService Requests](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=42>)
```
sum(increase(grpc_server_handled_total{app_kubernetes_io_name="argocd-server-metrics", job="kubernetes-service-endpoints", 
namespace=~"$namespace", grpc_service="cluster.ClusterService"}[$interval])) by (grpc_code, grpc_method)
```
to
```
sort_desc(sum(increase(grpc_server_handled_total{namespace=~"$namespace", 
grpc_service="cluster.ClusterService"}[$interval])) by (grpc_code, grpc_method))
```
- [gRPC Services - ProjectService Requests](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=44>)
```
sum(increase(grpc_server_handled_total{app_kubernetes_io_name="argocd-server-metrics", 
job="kubernetes-service-endpoints",namespace=~"$namespace",grpc_service="project.ProjectService"}[$interval])) by (grpc_code, grpc_method)
```
to
```
sort_desc(sum(increase(grpc_server_handled_total{namespace=~"$namespace",
grpc_service="project.ProjectService"}[$interval])) by (grpc_code, grpc_method))
```
- [gRPC Services - RepositoryService Requests](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=46>)
```
sum(increase(grpc_server_handled_total{app_kubernetes_io_name="argocd-server-metrics", 
job="kubernetes-service-endpoints", namespace=~"$namespace", grpc_service="repository.RepositoryService"}[$interval])) by (grpc_code, grpc_method)
```
to
```
sort_desc(sum(increase(grpc_server_handled_total{namespace=~"$namespace", 
grpc_service="repository.RepositoryService"}[$interval])) by (grpc_code, grpc_method))
```
- [gRPC Services - SessionService Requests](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=48>)
```
sum(increase(grpc_server_handled_total{app_kubernetes_io_name="argocd-server-metrics", 
job="kubernetes-service-endpoints",namespace=~"$namespace", grpc_service="session.SessionService"}[$interval])) by (grpc_code, grpc_method)
```
to
```
sort_desc(sum(increase(grpc_server_handled_total{namespace=~"$namespace", 
grpc_service="session.SessionService"}[$interval])) by (grpc_code, grpc_method))
```
- [gRPC Services - VersionService Requests](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=49>)
```
sum(increase(grpc_server_handled_total{app_kubernetes_io_name="argocd-server-metrics", 
job="kubernetes-service-endpoints", namespace=~"$namespace",grpc_service="version.VersionService"}[$interval])) by (grpc_code, grpc_method)
```
to
```
sort_desc(sum(increase(grpc_server_handled_total{namespace=~"$namespace",
grpc_service="version.VersionService"}[$interval])) by (grpc_code, grpc_method))
```
- [gRPC Services - AccountService Requests](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=50>)
```
sum(increase(grpc_server_handled_total{app_kubernetes_io_name="argocd-server-metrics", 
job="kubernetes-service-endpoints",namespace=~"$namespace",grpc_service="account.AccountService"}[$interval])) by (grpc_code, grpc_method)
```
to
```
sort_desc(sum(increase(grpc_server_handled_total{namespace=~"$namespace",
grpc_service="account.AccountService"}[$interval])) by (grpc_code, grpc_method))
```
- [gRPC Services - SettingsService Requests](<https://grafana.teleport.usummitapp.net/d/DRRqkYOnz/argocd?orgId=1&from=now-5m&to=now&editPanel=99>)
```
sum(increase(grpc_server_handled_total{app_kubernetes_io_name="argocd-server-metrics",
job="kubernetes-service-endpoints",namespace=~"$namespace", grpc_service="cluster.SettingsService"}[$interval])) by (grpc_code, grpc_method)
```
to
```
sort_desc(sum(increase(grpc_server_handled_total{namespace=~"$namespace", 
grpc_service="cluster.SettingsService"}[$interval])) by (grpc_code, grpc_method))
```