### PR TITLE
fix: edit `kubernetes cluster monitoring` dashboard configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,25 @@
 # Changelog
 
+## 2023-12-22
+
+[prod]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-grafana-dashboards/pull/7)
+- Fixed `Kubernetes - cluster monitoring` dashboard configuration
+
 ## 2023-12-18
 
 [prod]
 
 - [associated PR](https://github.com/saritasa-nest/saritasa-devops-grafana-dashboards/pull/5)
-- Fixed ArgoCD dashboard configuration
+- Fixed `ArgoCD` dashboard configuration
 
 ## 2023-12-15
 
 [prod]
 
 - [associated PR](https://github.com/saritasa-nest/saritasa-devops-grafana-dashboards/pull/4)
-- Fixed alertmanager dashboard configuration
+- Fixed `alertmanager` dashboard configuration
 
 ## 2023-11-23
 

--- a/kubernetes/kubernetes-cluster-monitoring.json
+++ b/kubernetes/kubernetes-cluster-monitoring.json
@@ -936,7 +936,7 @@
       "type": "stat"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -948,240 +948,242 @@
         "y": 16
       },
       "id": 35,
-      "panels": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "decimals": 3,
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 17
+          },
+          "height": "",
+          "hiddenSeries": false,
+          "id": 17,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 640,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (pod, namespace))",
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "{{ namespace }} / {{ pod }}",
+              "metric": "container_cpu",
+              "range": true,
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Pods CPU usage (1m avg)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:138",
+              "format": "none",
+              "label": "cores",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:139",
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        }
+      ],
       "title": "Pods CPU usage",
       "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
+      "collapsed": true,
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "decimals": 3,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
       "gridPos": {
-        "h": 7,
+        "h": 1,
         "w": 24,
         "x": 0,
         "y": 17
       },
-      "height": "",
-      "hiddenSeries": false,
-      "id": 17,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
+      "id": 36,
+      "panels": [
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (node, pod, namespace))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }}",
-          "metric": "container_cpu",
-          "range": true,
-          "refId": "A",
-          "step": 10
+          "decimals": 3,
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 27
+          },
+          "height": "",
+          "hiddenSeries": false,
+          "id": 23,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 640,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{name!=\"\",node=~\"^$Node$\", namespace=\"kube-system\"}[1m])) by (namespace, pod))",
+              "hide": false,
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "{{ namespace }} / {{ pod }} ",
+              "metric": "container_cpu",
+              "range": true,
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "System services CPU usage (1m avg)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:195",
+              "format": "none",
+              "label": "cores",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:196",
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Pods CPU usage (1m avg)",
-      "tooltip": {
-        "msResolution": true,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:138",
-          "format": "none",
-          "label": "cores",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:139",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 24
-      },
-      "id": 36,
-      "panels": [],
       "title": "System services CPU usage",
       "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 3,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 25
-      },
-      "height": "",
-      "hiddenSeries": false,
-      "id": 23,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{name!=\"\",node=~\"^$Node$\", namespace=\"kube-system\"}[1m])) by (name, namespace, node, pod))",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }} ",
-          "metric": "container_cpu",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "System services CPU usage (1m avg)",
-      "tooltip": {
-        "msResolution": true,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:195",
-          "format": "none",
-          "label": "cores",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:196",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
+      "collapsed": true,
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -1190,365 +1192,119 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
-      },
-      "id": 37,
-      "panels": [],
-      "title": "Containers CPU usage",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 3,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 33
-      },
-      "height": "",
-      "hiddenSeries": false,
-      "id": 24,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "hideEmpty": false,
-        "hideZero": false,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=\"\", container!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (container, node, pod, namespace))",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }}",
-          "metric": "container_cpu",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Containers CPU usage (1m avg)",
-      "tooltip": {
-        "msResolution": true,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:252",
-          "format": "none",
-          "label": "cores",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:253",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 40
-      },
-      "id": 38,
-      "panels": [],
-      "title": "All processes CPU usage",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 3,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 14,
-        "w": 24,
-        "x": 0,
-        "y": 41
-      },
-      "hiddenSeries": false,
-      "id": 20,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc(sum (rate (container_cpu_usage_seconds_total{id!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (id, node, pod, namespace))",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }}     ",
-          "metric": "container_cpu",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "All processes CPU usage (1m avg)",
-      "tooltip": {
-        "msResolution": true,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:309",
-          "format": "none",
-          "label": "cores",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:310",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 55
+        "y": 18
       },
       "id": 39,
-      "panels": [],
-      "title": "Pods memory usage",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 56
-      },
-      "hiddenSeries": false,
-      "id": 25,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
+      "panels": [
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}) by (node, pod, namespace))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }} ",
-          "metric": "container_memory_usage:sort_desc",
-          "range": true,
-          "refId": "A",
-          "step": 10
+          "decimals": 2,
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 38
+          },
+          "hiddenSeries": false,
+          "id": 25,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 640,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}) by (pod, namespace))",
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "{{ namespace }} / {{ pod }} ",
+              "metric": "container_memory_usage:sort_desc",
+              "range": true,
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Pods memory usage",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:366",
+              "format": "bytes",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:367",
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
       "title": "Pods memory usage",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:366",
-          "format": "bytes",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:367",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "type": "row"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -1557,118 +1313,119 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 63
+        "y": 19
       },
       "id": 40,
-      "panels": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "decimals": 2,
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 41
+          },
+          "hiddenSeries": false,
+          "id": 26,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 640,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sort_desc (sum (container_memory_working_set_bytes{name!=\"\",node=~\"^$Node$\", namespace=\"kube-system\"}) by (pod, namespace))",
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "{{ namespace }} / {{ pod }} ",
+              "metric": "container_memory_usage:sort_desc",
+              "range": true,
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "System services memory usage",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:423",
+              "format": "bytes",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:424",
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        }
+      ],
       "title": "System services memory usage",
       "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 64
-      },
-      "hiddenSeries": false,
-      "id": 26,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (container_memory_working_set_bytes{name!=\"\",node=~\"^$Node$\", namespace=\"kube-system\"}) by (node, pod, namespace, name))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }} ",
-          "metric": "container_memory_usage:sort_desc",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "System services memory usage",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:423",
-          "format": "bytes",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:424",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
+      "collapsed": true,
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -1677,629 +1434,134 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 71
-      },
-      "id": 41,
-      "panels": [],
-      "title": "Containers memory usage",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 72
-      },
-      "hiddenSeries": false,
-      "id": 27,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\", container!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}) by (container, node, pod, namespace))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }} | {{ container }}",
-          "metric": "container_memory_usage:sort_desc",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Containers memory usage",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:480",
-          "format": "bytes",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:481",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 79
-      },
-      "id": 42,
-      "panels": [],
-      "title": "All processes memory usage",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 14,
-        "w": 24,
-        "x": 0,
-        "y": 80
-      },
-      "hiddenSeries": false,
-      "id": 28,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (container_memory_working_set_bytes{id!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}) by (id, node, pod, namespace))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }} ",
-          "metric": "container_memory_usage:sort_desc",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "All processes memory usage",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:33",
-          "format": "bytes",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:34",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 94
+        "y": 20
       },
       "id": 43,
-      "panels": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "decimals": 2,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 53
+          },
+          "hiddenSeries": false,
+          "id": 16,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 640,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sort_desc (sum (rate (container_network_receive_bytes_total{image!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (pod, namespace))",
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "-> pod: {{ namespace }} / {{ pod }}",
+              "metric": "network",
+              "range": true,
+              "refId": "A",
+              "step": 10
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sort_desc (- sum (rate (container_network_transmit_bytes_total{image!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (pod, namespace))",
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "<-  pod: {{ namespace }} / {{ pod }}",
+              "metric": "network",
+              "range": true,
+              "refId": "B",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Pods network I/O (1m avg)",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:592",
+              "format": "Bps",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:593",
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        }
+      ],
       "title": "Pods network I/O",
       "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 95
-      },
-      "hiddenSeries": false,
-      "id": 16,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (rate (container_network_receive_bytes_total{image!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (node, pod, namespace))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "-> pod: {{ namespace }} / {{ pod }}",
-          "metric": "network",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (- sum (rate (container_network_transmit_bytes_total{image!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (node, pod, namespace))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "<-  pod: {{ namespace }} / {{ pod }}",
-          "metric": "network",
-          "range": true,
-          "refId": "B",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Pods network I/O (1m avg)",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:592",
-          "format": "Bps",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:593",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 102
-      },
-      "id": 44,
-      "panels": [],
-      "title": "Containers network I/O",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 103
-      },
-      "hiddenSeries": false,
-      "id": 30,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum (rate (container_network_transmit_bytes_total{image!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (namespace, pod)",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "<- pod: {{ namespace }} | {{ pod }}",
-          "metric": "network",
-          "range": true,
-          "refId": "D",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Containers network I/O (1m avg)",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:649",
-          "format": "Bps",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:650",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 110
-      },
-      "id": 45,
-      "panels": [],
-      "title": "All processes network I/O",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 14,
-        "w": 24,
-        "x": 0,
-        "y": 111
-      },
-      "hiddenSeries": false,
-      "id": 29,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (rate (container_network_receive_bytes_total{id!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (id, node, pod, namespace))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "-> pod: {{ namespace }} / {{ pod }}",
-          "metric": "network",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (- sum (rate (container_network_transmit_bytes_total{id!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (id, node, pod, namespace))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "<- pod: {{ namespace }} / {{ pod }}",
-          "metric": "network",
-          "range": true,
-          "refId": "B",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "All processes network I/O (1m avg)",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:706",
-          "format": "Bps",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:707",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
     }
   ],
-  "refresh": "10s",
+  "refresh": "30s",
   "schemaVersion": 38,
   "tags": [
     "kubernetes"
@@ -2370,8 +1632,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
-      "10s",
       "30s",
       "1m",
       "5m",
@@ -2396,6 +1656,6 @@
   "timezone": "browser",
   "title": "Kubernetes - Cluster Monitoring",
   "uid": "Yuvhycvnk",
-  "version": 43,
+  "version": 46,
   "weekStart": ""
 }

--- a/kubernetes/kubernetes-cluster-monitoring.json
+++ b/kubernetes/kubernetes-cluster-monitoring.json
@@ -108,7 +108,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum (rate (container_network_receive_bytes_total{node=~\"^$Node$\"}[1m]))",
+          "expr": "sum (rate (container_network_receive_bytes_total{node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m]))",
           "interval": "10s",
           "intervalFactor": 1,
           "legendFormat": "Received",
@@ -123,7 +123,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "- sum (rate (container_network_transmit_bytes_total{node=~\"^$Node$\"}[1m]))",
+          "expr": "- sum (rate (container_network_transmit_bytes_total{node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m]))",
           "interval": "10s",
           "intervalFactor": 1,
           "legendFormat": "Sent",
@@ -343,7 +343,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum (rate (container_cpu_usage_seconds_total{container!=\"\",node=~\"^$Node$\"}[1m])) / sum (machine_cpu_cores{node=~\"^$Node$\"}) * 100 ",
+          "expr": "sum (rate (container_cpu_usage_seconds_total{container!=\"\", node=~\"^$Node$\"}[1m])) / sum (machine_cpu_cores{node=~\"^$Node$\"}) * 100 ",
           "interval": "10s",
           "intervalFactor": 1,
           "range": true,
@@ -678,7 +678,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum (rate (container_cpu_usage_seconds_total{container!=\"\",node=~\"^$Node$\"}[1m]))",
+          "expr": "sum (rate (container_cpu_usage_seconds_total{container!=\"\", node=~\"^$Node$\"}[1m]))",
           "interval": "10s",
           "intervalFactor": 1,
           "range": true,
@@ -984,6 +984,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -1012,7 +1013,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=\"\",node=~\"^$Node$\"}[1m])) by (node, pod, namespace))",
+          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
           "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }}",
@@ -1039,12 +1040,14 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:138",
           "format": "none",
           "label": "cores",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:139",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -1103,6 +1106,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -1159,12 +1163,14 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:195",
           "format": "none",
           "label": "cores",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:196",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -1225,6 +1231,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -1253,7 +1260,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=\"\", container!=\"\", node=~\"^$Node$\"}[1m])) by (container, node, pod, namespace))",
+          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=\"\", container!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (container, node, pod, namespace))",
           "hide": false,
           "interval": "10s",
           "intervalFactor": 1,
@@ -1281,12 +1288,14 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:252",
           "format": "none",
           "label": "cores",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:253",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -1342,8 +1351,9 @@
         "current": true,
         "max": false,
         "min": false,
-        "rightSide": false,
+        "rightSide": true,
         "show": true,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -1372,7 +1382,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sort_desc(sum (rate (container_cpu_usage_seconds_total{id!=\"\", node=~\"^$Node$\"}[1m])) by (id, node, pod, namespace))",
+          "expr": "sort_desc(sum (rate (container_cpu_usage_seconds_total{id!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (id, node, pod, namespace))",
           "hide": false,
           "interval": "10s",
           "intervalFactor": 1,
@@ -1400,12 +1410,14 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:309",
           "format": "none",
           "label": "cores",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:310",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -1463,6 +1475,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -1491,7 +1504,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\", node=~\"^$Node$\"}) by (node, pod, namespace))",
+          "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}) by (node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
           "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }} ",
@@ -1518,11 +1531,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:366",
           "format": "bytes",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:367",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -1580,6 +1595,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -1635,11 +1651,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:423",
           "format": "bytes",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:424",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -1697,6 +1715,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -1725,7 +1744,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\", container!=\"\", node=~\"^$Node$\"}) by (container, node, pod, namespace))",
+          "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\", container!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}) by (container, node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
           "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }} | {{ container }}",
@@ -1752,11 +1771,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:480",
           "format": "bytes",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:481",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -1812,9 +1833,9 @@
         "current": true,
         "max": false,
         "min": false,
-        "rightSide": false,
+        "rightSide": true,
         "show": true,
-        "sideWidth": 200,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -1843,7 +1864,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sort_desc (sum (container_memory_working_set_bytes{id!=\"\",node=~\"^$Node$\"}) by (id, node, pod, namespace))",
+          "expr": "sort_desc (sum (container_memory_working_set_bytes{id!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}) by (id, node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
           "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }} ",
@@ -1870,11 +1891,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:33",
           "format": "bytes",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:34",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -1932,6 +1955,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -1960,7 +1984,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sort_desc (sum (rate (container_network_receive_bytes_total{image!=\"\", node=~\"^$Node$\"}[1m])) by (node, pod, namespace))",
+          "expr": "sort_desc (sum (rate (container_network_receive_bytes_total{image!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
           "legendFormat": "-> pod: {{ namespace }} / {{ pod }}",
@@ -1975,7 +1999,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sort_desc (- sum (rate (container_network_transmit_bytes_total{image!=\"\", node=~\"^$Node$\"}[1m])) by (node, pod, namespace))",
+          "expr": "sort_desc (- sum (rate (container_network_transmit_bytes_total{image!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
           "legendFormat": "<-  pod: {{ namespace }} / {{ pod }}",
@@ -2002,11 +2026,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:592",
           "format": "Bps",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:593",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -2064,6 +2090,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -2092,7 +2119,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum (rate (container_network_transmit_bytes_total{image!=\"\", node=~\"^$Node$\"}[1m])) by (namespace, pod)",
+          "expr": "sum (rate (container_network_transmit_bytes_total{image!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (namespace, pod)",
           "hide": false,
           "interval": "10s",
           "intervalFactor": 1,
@@ -2120,11 +2147,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:649",
           "format": "Bps",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:650",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -2180,9 +2209,9 @@
         "current": true,
         "max": false,
         "min": false,
-        "rightSide": false,
+        "rightSide": true,
         "show": true,
-        "sideWidth": 200,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -2211,7 +2240,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sort_desc (sum (rate (container_network_receive_bytes_total{id!=\"\", node=~\"^$Node$\"}[1m])) by (id, node, pod, namespace))",
+          "expr": "sort_desc (sum (rate (container_network_receive_bytes_total{id!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (id, node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
           "legendFormat": "-> pod: {{ namespace }} / {{ pod }}",
@@ -2226,7 +2255,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sort_desc (- sum (rate (container_network_transmit_bytes_total{id!=\"\", node=~\"^$Node$\"}[1m])) by (id, node, pod, namespace))",
+          "expr": "sort_desc (- sum (rate (container_network_transmit_bytes_total{id!=\"\", node=~\"^$Node$\", namespace=~\"^$Namespace$\"}[1m])) by (id, node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
           "legendFormat": "<- pod: {{ namespace }} / {{ pod }}",
@@ -2253,11 +2282,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:706",
           "format": "Bps",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:707",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -2302,6 +2333,34 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "name": "Namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       }
     ]
   },
@@ -2337,6 +2396,6 @@
   "timezone": "browser",
   "title": "Kubernetes - Cluster Monitoring",
   "uid": "Yuvhycvnk",
-  "version": 34,
+  "version": 43,
   "weekStart": ""
 }

--- a/kubernetes/kubernetes-cluster-monitoring.json
+++ b/kubernetes/kubernetes-cluster-monitoring.json
@@ -26,7 +26,7 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 315,
   "graphTooltip": 0,
-  "iteration": 1658922074780,
+  "id": 12,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -71,7 +71,6 @@
       "height": "200px",
       "hiddenSeries": false,
       "id": 32,
-      "isNew": true,
       "legend": {
         "alignAsTable": false,
         "avg": true,
@@ -94,7 +93,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -104,20 +103,32 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate (container_network_receive_bytes_total{kubernetes_io_hostname=~\"^$Node$\"}[1m]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate (container_network_receive_bytes_total{node=~\"^$Node$\"}[1m]))",
           "interval": "10s",
           "intervalFactor": 1,
           "legendFormat": "Received",
           "metric": "network",
+          "range": true,
           "refId": "A",
           "step": 10
         },
         {
-          "expr": "- sum (rate (container_network_transmit_bytes_total{kubernetes_io_hostname=~\"^$Node$\"}[1m]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "- sum (rate (container_network_transmit_bytes_total{node=~\"^$Node$\"}[1m]))",
           "interval": "10s",
           "intervalFactor": 1,
           "legendFormat": "Sent",
           "metric": "network",
+          "range": true,
           "refId": "B",
           "step": 10
         }
@@ -224,6 +235,8 @@
       "links": [],
       "maxDataPoints": 100,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -235,14 +248,20 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "expr": "sum (container_memory_working_set_bytes{id=\"/\",kubernetes_io_hostname=~\"^$Node$\"}) / sum (machine_memory_bytes{kubernetes_io_hostname=~\"^$Node$\"}) * 100",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "refId": "A",
-          "step": 10
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(1 - (\n          (\n            sum (node_memory_MemAvailable_bytes{job=\"node-exporter\", node=~\"^$Node$\"})\n            or\n            sum (\n            (\n              node_memory_Buffers_bytes{job=\"node-exporter\", node=~\"^$Node$\"}\n              +\n              node_memory_Cached_bytes{job=\"node-exporter\", node=~\"^$Node$\"}\n              +\n              node_memory_MemFree_bytes{job=\"node-exporter\", node=~\"^$Node$\"}\n              +\n              node_memory_Slab_bytes{job=\"node-exporter\", node=~\"^$Node$\"}\n            ))\n          )\n        /\n          sum (node_memory_MemTotal_bytes{job=\"node-exporter\", node=~\"^$Node$\"})\n        ))*100\n",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
         }
       ],
       "title": "Cluster memory usage",
@@ -303,6 +322,8 @@
       "links": [],
       "maxDataPoints": 100,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -314,12 +335,18 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{id=\"/\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) / sum (machine_cpu_cores{kubernetes_io_hostname=~\"^$Node$\"}) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate (container_cpu_usage_seconds_total{container!=\"\",node=~\"^$Node$\"}[1m])) / sum (machine_cpu_cores{node=~\"^$Node$\"}) * 100 ",
           "interval": "10s",
           "intervalFactor": 1,
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -382,6 +409,8 @@
       "links": [],
       "maxDataPoints": 100,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -393,18 +422,20 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum (container_fs_usage_bytes{id=\"/\",kubernetes_io_hostname=~\"^$Node$\"}) / sum (container_fs_limit_bytes{id=\"/\",kubernetes_io_hostname=~\"^$Node$\"}) * 100",
+          "editorMode": "code",
+          "expr": "100 - (sum (node_filesystem_avail_bytes{mountpoint!=\"\", node=~\"^$Node$\"}) / sum (node_filesystem_size_bytes{mountpoint!=\"\", node=~\"^$Node$\"}) * 100)",
           "interval": "10s",
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -472,14 +503,21 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "expr": "sum (container_memory_working_set_bytes{id=\"/\",kubernetes_io_hostname=~\"^$Node$\"})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (container_memory_working_set_bytes{container!=\"\", node=~\"^$Node$\"})",
           "interval": "10s",
           "intervalFactor": 1,
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -547,14 +585,21 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "expr": "sum (machine_memory_bytes{kubernetes_io_hostname=~\"^$Node$\"})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (machine_memory_bytes{node=~\"^$Node$\"})",
           "interval": "10s",
           "intervalFactor": 1,
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -622,14 +667,21 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{id=\"/\",kubernetes_io_hostname=~\"^$Node$\"}[1m]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate (container_cpu_usage_seconds_total{container!=\"\",node=~\"^$Node$\"}[1m]))",
           "interval": "10s",
           "intervalFactor": 1,
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -697,14 +749,21 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "expr": "sum (machine_cpu_cores{kubernetes_io_hostname=~\"^$Node$\"})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (machine_cpu_cores{node=~\"^$Node$\"})",
           "interval": "10s",
           "intervalFactor": 1,
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -772,18 +831,21 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum (container_fs_usage_bytes{id=\"/\",kubernetes_io_hostname=~\"^$Node$\"})",
+          "editorMode": "code",
+          "expr": "sum (node_filesystem_size_bytes{mountpoint!=\"\", node=~\"^$Node$\"}) - sum (node_filesystem_avail_bytes{mountpoint!=\"\", node=~\"^$Node$\"})",
           "interval": "10s",
           "intervalFactor": 1,
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -851,18 +913,21 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum (container_fs_limit_bytes{id=\"/\",kubernetes_io_hostname=~\"^$Node$\"})",
+          "editorMode": "code",
+          "expr": "sum (node_filesystem_size_bytes{mountpoint!=\"\", node=~\"^$Node$\"})",
           "interval": "10s",
           "intervalFactor": 1,
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -911,7 +976,6 @@
       "height": "",
       "hiddenSeries": false,
       "id": 17,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -933,7 +997,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -943,11 +1007,17 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (pod_name)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=\"\",node=~\"^$Node$\"}[1m])) by (node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }}",
           "metric": "container_cpu",
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -1025,7 +1095,6 @@
       "height": "",
       "hiddenSeries": false,
       "id": 23,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -1047,7 +1116,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1061,12 +1130,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum (rate (container_cpu_usage_seconds_total{name!=\"\",kubernetes_io_hostname=~\"^$Node$\", namespace=\"kube-system\"}[1m])) by (name)",
+          "editorMode": "code",
+          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{name!=\"\",node=~\"^$Node$\", namespace=\"kube-system\"}[1m])) by (name, namespace, node, pod))",
           "hide": false,
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "{{ systemd_service_name }}",
+          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }} ",
           "metric": "container_cpu",
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -1144,7 +1215,6 @@
       "height": "",
       "hiddenSeries": false,
       "id": 24,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -1168,7 +1238,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1178,32 +1248,19 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",container_name!=\"POD\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (container_name, pod_name)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=\"\", container!=\"\", node=~\"^$Node$\"}[1m])) by (container, node, pod, namespace))",
           "hide": false,
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "pod: {{ pod_name }} | {{ container_name }}",
+          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }}",
           "metric": "container_cpu",
+          "range": true,
           "refId": "A",
-          "step": 10
-        },
-        {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name!~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (kubernetes_io_hostname, name, image)",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "docker: {{ kubernetes_io_hostname }} | {{ image }} ({{ name }})",
-          "metric": "container_cpu",
-          "refId": "B",
-          "step": 10
-        },
-        {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{rkt_container_name!=\"\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (kubernetes_io_hostname, rkt_container_name)",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "rkt: {{ kubernetes_io_hostname }} | {{ rkt_container_name }}",
-          "metric": "container_cpu",
-          "refId": "C",
           "step": 10
         }
       ],
@@ -1279,7 +1336,6 @@
       },
       "hiddenSeries": false,
       "id": 20,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -1301,7 +1357,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1311,12 +1367,18 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{id!=\"/\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (id)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc(sum (rate (container_cpu_usage_seconds_total{id!=\"\", node=~\"^$Node$\"}[1m])) by (id, node, pod, namespace))",
           "hide": false,
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "{{ id }}",
+          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }}     ",
           "metric": "container_cpu",
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -1393,7 +1455,6 @@
       },
       "hiddenSeries": false,
       "id": 25,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -1402,7 +1463,6 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sideWidth": 200,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -1416,7 +1476,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1426,11 +1486,17 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}) by (pod_name)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\", node=~\"^$Node$\"}) by (node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }} ",
           "metric": "container_memory_usage:sort_desc",
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -1506,7 +1572,6 @@
       },
       "hiddenSeries": false,
       "id": 26,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -1515,7 +1580,6 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sideWidth": 200,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -1529,7 +1593,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1543,11 +1607,13 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum (container_memory_working_set_bytes{name!=\"\",kubernetes_io_hostname=~\"^$Node$\", namespace=\"kube-system\"}) by (name)",
+          "editorMode": "code",
+          "expr": "sort_desc (sum (container_memory_working_set_bytes{name!=\"\",node=~\"^$Node$\", namespace=\"kube-system\"}) by (node, pod, namespace, name))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "{{ systemd_service_name }}",
+          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }} ",
           "metric": "container_memory_usage:sort_desc",
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -1623,7 +1689,6 @@
       },
       "hiddenSeries": false,
       "id": 27,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -1632,7 +1697,6 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sideWidth": 200,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -1646,7 +1710,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1656,30 +1720,18 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",container_name!=\"POD\",kubernetes_io_hostname=~\"^$Node$\"}) by (container_name, pod_name)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\", container!=\"\", node=~\"^$Node$\"}) by (container, node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "pod: {{ pod_name }} | {{ container_name }}",
+          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }} | {{ container }}",
           "metric": "container_memory_usage:sort_desc",
+          "range": true,
           "refId": "A",
-          "step": 10
-        },
-        {
-          "expr": "sum (container_memory_working_set_bytes{image!=\"\",name!~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}) by (kubernetes_io_hostname, name, image)",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "docker: {{ kubernetes_io_hostname }} | {{ image }} ({{ name }})",
-          "metric": "container_memory_usage:sort_desc",
-          "refId": "B",
-          "step": 10
-        },
-        {
-          "expr": "sum (container_memory_working_set_bytes{rkt_container_name!=\"\",kubernetes_io_hostname=~\"^$Node$\"}) by (kubernetes_io_hostname, rkt_container_name)",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "rkt: {{ kubernetes_io_hostname }} | {{ rkt_container_name }}",
-          "metric": "container_memory_usage:sort_desc",
-          "refId": "C",
           "step": 10
         }
       ],
@@ -1754,7 +1806,6 @@
       },
       "hiddenSeries": false,
       "id": 28,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -1777,7 +1828,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1787,11 +1838,17 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum (container_memory_working_set_bytes{id!=\"/\",kubernetes_io_hostname=~\"^$Node$\"}) by (id)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (container_memory_working_set_bytes{id!=\"\",node=~\"^$Node$\"}) by (id, node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "{{ id }}",
+          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }} ",
           "metric": "container_memory_usage:sort_desc",
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -1867,7 +1924,6 @@
       },
       "hiddenSeries": false,
       "id": 16,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -1876,7 +1932,6 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sideWidth": 200,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -1890,7 +1945,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1900,20 +1955,32 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (pod_name)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (rate (container_network_receive_bytes_total{image!=\"\", node=~\"^$Node$\"}[1m])) by (node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "-> {{ pod_name }}",
+          "legendFormat": "-> pod: {{ namespace }} / {{ pod }}",
           "metric": "network",
+          "range": true,
           "refId": "A",
           "step": 10
         },
         {
-          "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (pod_name)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (- sum (rate (container_network_transmit_bytes_total{image!=\"\", node=~\"^$Node$\"}[1m])) by (node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "<- {{ pod_name }}",
+          "legendFormat": "<-  pod: {{ namespace }} / {{ pod }}",
           "metric": "network",
+          "range": true,
           "refId": "B",
           "step": 10
         }
@@ -1989,7 +2056,6 @@
       },
       "hiddenSeries": false,
       "id": 30,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -1998,7 +2064,6 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sideWidth": 200,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -2012,7 +2077,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2022,63 +2087,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (container_name, pod_name)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate (container_network_transmit_bytes_total{image!=\"\", node=~\"^$Node$\"}[1m])) by (namespace, pod)",
           "hide": false,
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "-> pod: {{ pod_name }} | {{ container_name }}",
+          "legendFormat": "<- pod: {{ namespace }} | {{ pod }}",
           "metric": "network",
-          "refId": "B",
-          "step": 10
-        },
-        {
-          "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (container_name, pod_name)",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "<- pod: {{ pod_name }} | {{ container_name }}",
-          "metric": "network",
+          "range": true,
           "refId": "D",
-          "step": 10
-        },
-        {
-          "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name!~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (kubernetes_io_hostname, name, image)",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "-> docker: {{ kubernetes_io_hostname }} | {{ image }} ({{ name }})",
-          "metric": "network",
-          "refId": "A",
-          "step": 10
-        },
-        {
-          "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name!~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (kubernetes_io_hostname, name, image)",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "<- docker: {{ kubernetes_io_hostname }} | {{ image }} ({{ name }})",
-          "metric": "network",
-          "refId": "C",
-          "step": 10
-        },
-        {
-          "expr": "sum (rate (container_network_transmit_bytes_total{rkt_container_name!=\"\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (kubernetes_io_hostname, rkt_container_name)",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "-> rkt: {{ kubernetes_io_hostname }} | {{ rkt_container_name }}",
-          "metric": "network",
-          "refId": "E",
-          "step": 10
-        },
-        {
-          "expr": "- sum (rate (container_network_transmit_bytes_total{rkt_container_name!=\"\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (kubernetes_io_hostname, rkt_container_name)",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "<- rkt: {{ kubernetes_io_hostname }} | {{ rkt_container_name }}",
-          "metric": "network",
-          "refId": "F",
           "step": 10
         }
       ],
@@ -2153,7 +2174,6 @@
       },
       "hiddenSeries": false,
       "id": 29,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -2176,7 +2196,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2186,20 +2206,32 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate (container_network_receive_bytes_total{id!=\"/\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (id)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (rate (container_network_receive_bytes_total{id!=\"\", node=~\"^$Node$\"}[1m])) by (id, node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "-> {{ id }}",
+          "legendFormat": "-> pod: {{ namespace }} / {{ pod }}",
           "metric": "network",
+          "range": true,
           "refId": "A",
           "step": 10
         },
         {
-          "expr": "- sum (rate (container_network_transmit_bytes_total{id!=\"/\",kubernetes_io_hostname=~\"^$Node$\"}[1m])) by (id)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (- sum (rate (container_network_transmit_bytes_total{id!=\"\", node=~\"^$Node$\"}[1m])) by (id, node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "<- {{ id }}",
+          "legendFormat": "<- pod: {{ namespace }} / {{ pod }}",
           "metric": "network",
+          "range": true,
           "refId": "B",
           "step": 10
         }
@@ -2237,8 +2269,7 @@
     }
   ],
   "refresh": "10s",
-  "schemaVersion": 36,
-  "style": "dark",
+  "schemaVersion": 38,
   "tags": [
     "kubernetes"
   ],
@@ -2247,23 +2278,24 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": true,
-          "text": "ip-10-110-4-28.ec2.internal",
-          "value": "ip-10-110-4-28.ec2.internal"
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": {
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "",
+        "definition": "label_values(node)",
         "hide": 0,
         "includeAll": true,
         "multi": false,
         "name": "Node",
         "options": [],
         "query": {
-          "query": "label_values(kubernetes_io_hostname)",
-          "refId": "Prometheus-Node-Variable-Query"
+          "qryType": 1,
+          "query": "label_values(node)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -2305,6 +2337,6 @@
   "timezone": "browser",
   "title": "Kubernetes - Cluster Monitoring",
   "uid": "Yuvhycvnk",
-  "version": 1,
+  "version": 34,
   "weekStart": ""
 }


### PR DESCRIPTION
### Summary

JIRA: <https://saritasa.atlassian.net/browse/USAWS-20>

Fixed [Kubernetes - Cluster Monitoring](<https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s>) grafana dashboard configuration.

i edited url for `Kubernetes - Cluster Monitoring` dashboard:
<https://github.com/saritasa-nest/usummit-kubernetes-aws/blob/feature/fix-grafana-dashboards/config/addons/monitoring/prometheus/values.yaml#L358>

Edited:
- [Network I/O pressure](<https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&var-Node=All&editPanel=32>)

**A**
```bash
sum (rate (container_network_receive_bytes_total{kubernetes_io_hostname=~"^$Node$"}[1m]))
```
to
```bash
sum (rate (container_network_receive_bytes_total{node=~"^$Node$", namespace=~"^$Namespace$"}[1m]))
```
**B**
```bash
- sum (rate (container_network_transmit_bytes_total{kubernetes_io_hostname=~"^$Node$"}[1m]))
```
to
```bash
- sum (rate (container_network_transmit_bytes_total{node=~"^$Node$", namespace=~"^$Namespace$"}[1m]))
```
- [Total usage - Cluster memory usage](<https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&editPanel=4>)
```bash
sum (container_memory_working_set_bytes{id="/",kubernetes_io_hostname=~"^$Node$"}) / sum (machine_memory_bytes{kubernetes_io_hostname=~"^$Node$"}) * 100
```
to
```bash
(1 - (
          (
            sum (node_memory_MemAvailable_bytes{job="node-exporter", node=~"^$Node$"})
            or
            sum (
            (
              node_memory_Buffers_bytes{job="node-exporter", node=~"^$Node$"}
              +
              node_memory_Cached_bytes{job="node-exporter", node=~"^$Node$"}
              +
              node_memory_MemFree_bytes{job="node-exporter", node=~"^$Node$"}
              +
              node_memory_Slab_bytes{job="node-exporter", node=~"^$Node$"}
            ))
          )
        /
          sum (node_memory_MemTotal_bytes{job="node-exporter", node=~"^$Node$"})
        ))*100

```
- [Total usage - Used memory](<https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&editPanel=9>)
```bash
sum (container_memory_working_set_bytes{id="/",kubernetes_io_hostname=~"^$Node$"})
```
to
```bash
sum (container_memory_working_set_bytes{container!="", node=~"^$Node$"})
```
- [Total usage - Total memory](<https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&var-Node=All&editPanel=10>)
```bash
sum (machine_memory_bytes{kubernetes_io_hostname=~"^$Node$"})
```
to
```bash
sum (machine_memory_bytes{node=~"^$Node$"})
```
- [Total usage - Cluster CPU usage](<https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&var-Node=All&editPanel=6>)
```bash
sum (rate (container_cpu_usage_seconds_total{id="/",kubernetes_io_hostname=~"^$Node$"}[1m])) / sum (machine_cpu_cores{kubernetes_io_hostname=~"^$Node$"}) * 100
```
to
```bash
sum (rate (container_cpu_usage_seconds_total{container!="", node=~"^$Node$"}[1m])) / sum (machine_cpu_cores{node=~"^$Node$"}) * 100
```
- [Total usage - Used CPU](<https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&var-Node=All&editPanel=11>)
```bash
sum (rate (container_cpu_usage_seconds_total{id="/",kubernetes_io_hostname=~"^$Node$"}[1m]))
```
to
```bash
sum (rate (container_cpu_usage_seconds_total{container!="", node=~"^$Node$"}[1m]))
```
- [Total usage - Total CPU](<https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&var-Node=All&editPanel=12>)
```bash
sum (machine_cpu_cores{kubernetes_io_hostname=~"^$Node$"})
```
to
```bash
sum (machine_cpu_cores{node=~"^$Node$"})
```
- [Total usage - Cluster filesystem usage](<https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&var-Node=All&editPanel=7>)
```bash
sum (container_fs_usage_bytes{id="/",kubernetes_io_hostname=~"^$Node$"}) / sum (container_fs_limit_bytes{id="/",kubernetes_io_hostname=~"^$Node$"}) * 100
```
to
```bash
100 - (sum (node_filesystem_avail_bytes{mountpoint!="", node=~"^$Node$"}) / sum (node_filesystem_size_bytes{mountpoint!="", node=~"^$Node$"}) * 100)
```
- [Total usage - Used filesystem](https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&var-Node=All&editPanel=13)
```bash
sum (container_fs_usage_bytes{id="/",kubernetes_io_hostname=~"^$Node$"})
```
to
```bash
sum (node_filesystem_size_bytes{mountpoint!="", node=~"^$Node$"}) - sum (node_filesystem_avail_bytes{mountpoint!="", node=~"^$Node$"})
```
- [Total usage - Total filesystem](https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&var-Node=All&editPanel=14)
```bash
sum (container_fs_limit_bytes{id="/",kubernetes_io_hostname=~"^$Node$"})
```
to
```bash
sum (node_filesystem_size_bytes{mountpoint!="", node=~"^$Node$"})
```
- [Pods CPU usage](<https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&var-Node=All&editPanel=17>)
```bash
sum (rate (container_cpu_usage_seconds_total{image!="",name=~"^k8s_.*",kubernetes_io_hostname=~"^$Node$"}[1m])) by (pod_name)
```
to
```bash
sort_desc (sum (rate (container_cpu_usage_seconds_total{image!="", node=~"^$Node$", namespace=~"^$Namespace$"}[1m])) by (pod, namespace))
```
- [System services CPU usage](<https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&var-Node=All&editPanel=23>)
```bash
sum (rate (container_cpu_usage_seconds_total{name!="",kubernetes_io_hostname=~"^$Node$", namespace="kube-system"}[1m])) by (name)
```
to
```bash
sort_desc (sum (rate (container_cpu_usage_seconds_total{name!="",node=~"^$Node$", namespace="kube-system"}[1m])) by (name, namespace, pod))
```
- [Pods memory usage](<https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&var-Node=All&editPanel=25>)
```bash
sum (container_memory_working_set_bytes{image!="",name=~"^k8s_.*",kubernetes_io_hostname=~"^$Node$"}) by (pod_name)
```
to
```bash
sort_desc( sum (container_memory_working_set_bytes{image!="", node=~"^$Node$", namespace=~"^$Namespace$"}) by (pod, namespace))
```
- [System services memory usage](<https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&var-Node=All&editPanel=26>)
```bash
sum (container_memory_working_set_bytes{name!="",kubernetes_io_hostname=~"^$Node$", namespace="kube-system"}) by (name)
```
to
```bash
sort_desc (sum (container_memory_working_set_bytes{name!="",node=~"^$Node$", namespace="kube-system"}) by (pod, namespace))
```
- [Pods network I/O](<https://grafana.teleport.usummitapp.net/d/Yuvhycvnk/kubernetes-cluster-monitoring?orgId=1&refresh=10s&var-Node=All&editPanel=16>)

**A**
```bash
sum (rate (container_network_receive_bytes_total{image!="",name=~"^k8s_.*",kubernetes_io_hostname=~"^$Node$"}[1m])) by (pod_name)
```
to
```bash
sort_desc (sum (rate (container_network_receive_bytes_total{image!="", node=~"^$Node$", namespace=~"^$Namespace$"}[1m])) by (pod, namespace))
```
**B**
```bash
- sum (rate (container_network_transmit_bytes_total{image!="",name=~"^k8s_.*",kubernetes_io_hostname=~"^$Node$"}[1m])) by (pod_name)
```
to
```bash
sort_desc (- sum (rate (container_network_transmit_bytes_total{image!="", node=~"^$Node$", namespace=~"^$Namespace$"}[1m])) by (pod, namespace))
```