### PR TITLE
fix: edit `kubernetes - cluster overall` dashboard configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [prod]
 
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-grafana-dashboards/pull/9)
+- Fixed Kubernetes - cluster overall dashboard configuration
+
+## 2023-12-22
+
+[prod]
+
 - [associated PR](https://github.com/saritasa-nest/saritasa-devops-grafana-dashboards/pull/6)
 - Fixed Kubernetes - cluster overview dashboard configuration
 

--- a/kubernetes/kubernetes-cluster-overall.json
+++ b/kubernetes/kubernetes-cluster-overall.json
@@ -505,7 +505,7 @@
       "fill": 10,
       "fillGradient": 0,
       "gridPos": {
-        "h": 6,
+        "h": 8,
         "w": 12,
         "x": 0,
         "y": 8
@@ -593,7 +593,7 @@
       "fill": 10,
       "fillGradient": 0,
       "gridPos": {
-        "h": 6,
+        "h": 8,
         "w": 12,
         "x": 12,
         "y": 8
@@ -676,7 +676,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 16
       },
       "id": 34,
       "panels": [],
@@ -716,7 +716,7 @@
         "h": 3,
         "w": 6,
         "x": 0,
-        "y": 15
+        "y": 17
       },
       "id": 2071,
       "options": {
@@ -792,7 +792,7 @@
         "h": 3,
         "w": 3,
         "x": 6,
-        "y": 15
+        "y": 17
       },
       "id": 12,
       "links": [],
@@ -868,7 +868,7 @@
         "h": 3,
         "w": 3,
         "x": 9,
-        "y": 15
+        "y": 17
       },
       "id": 11,
       "links": [],
@@ -951,7 +951,7 @@
         "h": 3,
         "w": 3,
         "x": 12,
-        "y": 15
+        "y": 17
       },
       "id": 10,
       "links": [],
@@ -1027,7 +1027,7 @@
         "h": 3,
         "w": 3,
         "x": 15,
-        "y": 15
+        "y": 17
       },
       "id": 9,
       "links": [],
@@ -1109,7 +1109,7 @@
         "h": 3,
         "w": 3,
         "x": 18,
-        "y": 15
+        "y": 17
       },
       "id": 14,
       "links": [],
@@ -1191,7 +1191,7 @@
         "h": 3,
         "w": 3,
         "x": 21,
-        "y": 15
+        "y": 17
       },
       "id": 13,
       "links": [],
@@ -1262,7 +1262,7 @@
         "h": 3,
         "w": 3,
         "x": 0,
-        "y": 18
+        "y": 20
       },
       "id": 2063,
       "options": {
@@ -1326,7 +1326,7 @@
         "h": 3,
         "w": 3,
         "x": 3,
-        "y": 18
+        "y": 20
       },
       "id": 2065,
       "options": {
@@ -1409,7 +1409,7 @@
         "h": 3,
         "w": 6,
         "x": 6,
-        "y": 18
+        "y": 20
       },
       "id": 6,
       "links": [],
@@ -1497,7 +1497,7 @@
         "h": 3,
         "w": 6,
         "x": 12,
-        "y": 18
+        "y": 20
       },
       "id": 4,
       "links": [],
@@ -1586,7 +1586,7 @@
         "h": 3,
         "w": 6,
         "x": 18,
-        "y": 18
+        "y": 20
       },
       "id": 7,
       "links": [],
@@ -1658,7 +1658,7 @@
         "h": 3,
         "w": 3,
         "x": 0,
-        "y": 21
+        "y": 23
       },
       "id": 2067,
       "options": {
@@ -1722,7 +1722,7 @@
         "h": 3,
         "w": 3,
         "x": 3,
-        "y": 21
+        "y": 23
       },
       "id": 2069,
       "options": {
@@ -1777,7 +1777,7 @@
         "h": 7,
         "w": 10,
         "x": 6,
-        "y": 21
+        "y": 23
       },
       "hiddenSeries": false,
       "id": 2085,
@@ -1908,7 +1908,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 21
+        "y": 23
       },
       "id": 2101,
       "options": {
@@ -1965,8 +1965,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1981,7 +1980,7 @@
         "h": 3,
         "w": 3,
         "x": 0,
-        "y": 24
+        "y": 26
       },
       "id": 2082,
       "options": {
@@ -2030,8 +2029,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2046,7 +2044,7 @@
         "h": 3,
         "w": 3,
         "x": 3,
-        "y": 24
+        "y": 26
       },
       "id": 2083,
       "options": {
@@ -2095,8 +2093,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2111,7 +2108,7 @@
         "h": 3,
         "w": 3,
         "x": 0,
-        "y": 27
+        "y": 29
       },
       "id": 2080,
       "options": {
@@ -2160,8 +2157,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2176,7 +2172,7 @@
         "h": 3,
         "w": 3,
         "x": 3,
-        "y": 27
+        "y": 29
       },
       "id": 2081,
       "options": {
@@ -2224,7 +2220,7 @@
         "h": 8,
         "w": 18,
         "x": 6,
-        "y": 28
+        "y": 30
       },
       "hiddenSeries": false,
       "id": 2105,
@@ -2261,7 +2257,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(kube_pod_container_status_waiting_reason{})",
+          "expr": "sum(kube_pod_container_status_waiting{})",
           "format": "time_series",
           "interval": "",
           "legendFormat": "Total",
@@ -2274,11 +2270,13 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(kube_pod_container_status_waiting_reason{} == 1)  by(pod,reason)",
+          "editorMode": "code",
+          "expr": "sum (kube_pod_container_status_waiting{} == 1) by (namespace, pod)",
           "format": "time_series",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{pod}} {{reason}}",
+          "legendFormat": "{{ namespace }} / {{ pod }}",
+          "range": true,
           "refId": "B"
         }
       ],
@@ -2330,8 +2328,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2346,7 +2343,7 @@
         "h": 3,
         "w": 3,
         "x": 0,
-        "y": 30
+        "y": 32
       },
       "id": 2095,
       "options": {
@@ -2395,8 +2392,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2411,7 +2407,7 @@
         "h": 3,
         "w": 3,
         "x": 3,
-        "y": 30
+        "y": 32
       },
       "id": 2097,
       "options": {
@@ -2458,7 +2454,7 @@
         "h": 3,
         "w": 6,
         "x": 0,
-        "y": 33
+        "y": 35
       },
       "hiddenSeries": false,
       "id": 2104,
@@ -2563,10 +2559,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 6,
+        "h": 7,
         "w": 8,
         "x": 0,
-        "y": 36
+        "y": 38
       },
       "hiddenSeries": false,
       "id": 2052,
@@ -2669,10 +2665,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 6,
+        "h": 7,
         "w": 8,
         "x": 8,
-        "y": 36
+        "y": 38
       },
       "hiddenSeries": false,
       "id": 2053,
@@ -2777,10 +2773,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 6,
+        "h": 7,
         "w": 8,
         "x": 16,
-        "y": 36
+        "y": 38
       },
       "hiddenSeries": false,
       "id": 2051,
@@ -2888,7 +2884,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 45
       },
       "id": 2087,
       "legend": {
@@ -3212,7 +3208,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 52
       },
       "id": 2089,
       "interval": "1m",
@@ -3461,7 +3457,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 56
+        "y": 59
       },
       "id": 2022,
       "panels": [
@@ -3486,7 +3482,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 16
+            "y": 60
           },
           "hiddenSeries": false,
           "id": 2058,
@@ -3614,7 +3610,7 @@
             "h": 3,
             "w": 4,
             "x": 12,
-            "y": 16
+            "y": 60
           },
           "id": 2056,
           "links": [],
@@ -3691,7 +3687,7 @@
             "h": 3,
             "w": 4,
             "x": 16,
-            "y": 16
+            "y": 60
           },
           "id": 2059,
           "links": [],
@@ -3768,7 +3764,7 @@
             "h": 3,
             "w": 4,
             "x": 20,
-            "y": 16
+            "y": 60
           },
           "id": 2061,
           "links": [],
@@ -3845,7 +3841,7 @@
             "h": 3,
             "w": 4,
             "x": 12,
-            "y": 19
+            "y": 63
           },
           "id": 2026,
           "links": [],
@@ -3922,7 +3918,7 @@
             "h": 3,
             "w": 4,
             "x": 16,
-            "y": 19
+            "y": 63
           },
           "id": 2025,
           "links": [],
@@ -3999,7 +3995,7 @@
             "h": 3,
             "w": 4,
             "x": 20,
-            "y": 19
+            "y": 63
           },
           "id": 2060,
           "links": [],
@@ -4045,7 +4041,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 60
       },
       "id": 2014,
       "panels": [
@@ -4065,7 +4061,7 @@
             "h": 5,
             "w": 6,
             "x": 0,
-            "y": 17
+            "y": 61
           },
           "id": 2016,
           "links": [],
@@ -4179,7 +4175,7 @@
             "h": 5,
             "w": 6,
             "x": 6,
-            "y": 17
+            "y": 61
           },
           "id": 2018,
           "links": [],
@@ -4254,7 +4250,7 @@
             "h": 5,
             "w": 6,
             "x": 12,
-            "y": 17
+            "y": 61
           },
           "id": 2019,
           "links": [],
@@ -4327,7 +4323,7 @@
             "h": 5,
             "w": 6,
             "x": 18,
-            "y": 17
+            "y": 61
           },
           "id": 2020,
           "links": [],
@@ -4373,7 +4369,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 61
       },
       "id": 2045,
       "panels": [
@@ -4419,7 +4415,7 @@
             "h": 3,
             "w": 8,
             "x": 0,
-            "y": 18
+            "y": 62
           },
           "id": 2047,
           "links": [],
@@ -4493,7 +4489,7 @@
             "h": 3,
             "w": 8,
             "x": 8,
-            "y": 18
+            "y": 62
           },
           "id": 2048,
           "links": [],
@@ -4567,7 +4563,7 @@
             "h": 3,
             "w": 8,
             "x": 16,
-            "y": 18
+            "y": 62
           },
           "id": 2049,
           "links": [],
@@ -4613,7 +4609,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 62
       },
       "id": 2028,
       "panels": [
@@ -4659,7 +4655,7 @@
             "h": 3,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 63
           },
           "id": 2030,
           "links": [],
@@ -4734,7 +4730,7 @@
             "h": 3,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 63
           },
           "id": 2031,
           "links": [],
@@ -4810,7 +4806,7 @@
             "h": 3,
             "w": 6,
             "x": 0,
-            "y": 22
+            "y": 66
           },
           "id": 2033,
           "links": [],
@@ -4885,7 +4881,7 @@
             "h": 3,
             "w": 10,
             "x": 6,
-            "y": 22
+            "y": 66
           },
           "id": 2032,
           "links": [],
@@ -4961,7 +4957,7 @@
             "h": 3,
             "w": 8,
             "x": 16,
-            "y": 22
+            "y": 66
           },
           "id": 2034,
           "links": [],
@@ -5008,7 +5004,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 60
+        "y": 63
       },
       "id": 2036,
       "panels": [
@@ -5054,7 +5050,7 @@
             "h": 3,
             "w": 6,
             "x": 0,
-            "y": 20
+            "y": 64
           },
           "id": 2038,
           "links": [],
@@ -5128,7 +5124,7 @@
             "h": 3,
             "w": 6,
             "x": 6,
-            "y": 20
+            "y": 64
           },
           "id": 2039,
           "links": [],
@@ -5202,7 +5198,7 @@
             "h": 3,
             "w": 6,
             "x": 12,
-            "y": 20
+            "y": 64
           },
           "id": 2040,
           "links": [],
@@ -5276,7 +5272,7 @@
             "h": 3,
             "w": 6,
             "x": 18,
-            "y": 20
+            "y": 64
           },
           "id": 2041,
           "links": [],
@@ -5350,7 +5346,7 @@
             "h": 3,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 67
           },
           "id": 2043,
           "links": [],
@@ -5430,7 +5426,7 @@
             "h": 3,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 67
           },
           "id": 2042,
           "links": [],
@@ -5473,7 +5469,7 @@
       "type": "row"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -5482,124 +5478,374 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 61
+        "y": 64
       },
       "id": 33,
-      "panels": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "decimals": 2,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 5,
+            "w": 24,
+            "x": 0,
+            "y": 65
+          },
+          "height": "200px",
+          "hiddenSeries": false,
+          "id": 32,
+          "legend": {
+            "alignAsTable": false,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": false,
+            "sideWidth": 200,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum (rate (container_network_receive_bytes_total{}[5m]))",
+              "format": "time_series",
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "Received",
+              "metric": "network",
+              "refId": "A",
+              "step": 10
+            },
+            {
+              "expr": "- sum (rate (container_network_transmit_bytes_total{}[5m]))",
+              "format": "time_series",
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "Sent",
+              "metric": "network",
+              "refId": "B",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Network I/O pressure (5m avg)",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:943",
+              "format": "Bps",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:944",
+              "format": "Bps",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        }
+      ],
       "title": "Network I/O pressure",
       "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
+      "collapsed": true,
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {},
       "gridPos": {
-        "h": 5,
+        "h": 1,
         "w": 24,
         "x": 0,
-        "y": 62
+        "y": 65
       },
-      "height": "200px",
-      "hiddenSeries": false,
-      "id": 32,
-      "legend": {
-        "alignAsTable": false,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": false,
-        "sideWidth": 200,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
+      "id": 35,
+      "panels": [
         {
-          "expr": "sum (rate (container_network_receive_bytes_total{}[5m]))",
-          "format": "time_series",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "Received",
-          "metric": "network",
-          "refId": "A",
-          "step": 10
-        },
-        {
-          "expr": "- sum (rate (container_network_transmit_bytes_total{}[5m]))",
-          "format": "time_series",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "Sent",
-          "metric": "network",
-          "refId": "B",
-          "step": 10
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "decimals": 3,
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 14,
+            "w": 24,
+            "x": 0,
+            "y": 66
+          },
+          "height": "",
+          "hiddenSeries": false,
+          "id": 17,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 600,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=\"\"}[5m])) by (pod, namespace))",
+              "format": "time_series",
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "{{ namespace }} / {{ pod }}",
+              "metric": "container_cpu",
+              "range": true,
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Pods CPU usage (5m avg)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:1205",
+              "format": "percentunit",
+              "label": "cores",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:1206",
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Network I/O pressure (5m avg)",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 0,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:943",
-          "format": "Bps",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:944",
-          "format": "Bps",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "title": "Pods CPU usage",
+      "type": "row"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 36,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "decimals": 3,
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 67
+          },
+          "height": "",
+          "hiddenSeries": false,
+          "id": 23,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 600,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum (rate (container_cpu_usage_seconds_total{name!=\"\", namespace=\"kube-system\"}[5m]))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "system services cpu",
+              "metric": "container_cpu",
+              "range": true,
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "System services CPU usage (5m avg)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:1262",
+              "format": "percentunit",
+              "label": "cores",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:1263",
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        }
+      ],
+      "title": "System services CPU usage",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -5610,733 +5856,239 @@
         "x": 0,
         "y": 67
       },
-      "id": 35,
-      "panels": [],
-      "title": "Pods CPU usage",
+      "id": 39,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "decimals": 2,
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 68
+          },
+          "hiddenSeries": false,
+          "id": 25,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 600,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\"}) by (pod, namespace))",
+              "format": "time_series",
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "{{ namespace }} / {{ pod }}",
+              "metric": "container_memory_usage:sort_desc",
+              "range": true,
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Pods memory usage",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:1745",
+              "format": "bytes",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:1746",
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        }
+      ],
+      "title": "Pods memory usage",
       "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
+      "collapsed": true,
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "decimals": 3,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
       "gridPos": {
-        "h": 7,
+        "h": 1,
         "w": 24,
         "x": 0,
         "y": 68
       },
-      "height": "",
-      "hiddenSeries": false,
-      "id": 17,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=\"\"}[5m])) by (node, pod, namespace))",
-          "format": "time_series",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "{{ node }} ----{{ namespace }} / {{ pod }}",
-          "metric": "container_cpu",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Pods CPU usage (5m avg)",
-      "tooltip": {
-        "msResolution": true,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1205",
-          "format": "percentunit",
-          "label": "cores",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1206",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 75
-      },
-      "id": 36,
-      "panels": [],
-      "title": "System services CPU usage",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 3,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 76
-      },
-      "height": "",
-      "hiddenSeries": false,
-      "id": 23,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum (rate (container_cpu_usage_seconds_total{name!=\"\", namespace=\"kube-system\"}[5m]))",
-          "format": "time_series",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "system services cpu",
-          "metric": "container_cpu",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "System services CPU usage (5m avg)",
-      "tooltip": {
-        "msResolution": true,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1262",
-          "format": "percentunit",
-          "label": "cores",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1263",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 83
-      },
-      "id": 37,
-      "panels": [],
-      "title": "Containers CPU usage",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 3,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 84
-      },
-      "height": "",
-      "hiddenSeries": false,
-      "id": 24,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "hideEmpty": false,
-        "hideZero": false,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=\"\", container!=\"\"}[5m])) by (node, pod, namespace))",
-          "format": "time_series",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "{{ node }} ---- {{ namespace }} / {{ pod }}",
-          "metric": "container_cpu",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Containers CPU usage (5m avg)",
-      "tooltip": {
-        "msResolution": true,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1398",
-          "format": "percentunit",
-          "label": "cores",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1399",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 91
-      },
-      "id": 38,
-      "panels": [],
-      "title": "All processes CPU usage",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 3,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 13,
-        "w": 24,
-        "x": 0,
-        "y": 92
-      },
-      "hiddenSeries": false,
-      "id": 20,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{id!=\"\"}[5m])) by (id, node, pod, namespace))",
-          "format": "time_series",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }}",
-          "metric": "container_cpu",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "All processes CPU usage (5m avg)",
-      "tooltip": {
-        "msResolution": true,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1609",
-          "format": "percentunit",
-          "label": "cores",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1610",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 105
-      },
-      "id": 39,
-      "panels": [],
-      "title": "Pods memory usage",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 106
-      },
-      "hiddenSeries": false,
-      "id": 25,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\"}) by (node, pod, namespace))",
-          "format": "time_series",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "{{ node }} ---- {{ namespace }} / {{ pod }}",
-          "metric": "container_memory_usage:sort_desc",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Pods memory usage",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1745",
-          "format": "bytes",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1746",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 113
-      },
       "id": 40,
-      "panels": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "decimals": 2,
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 69
+          },
+          "hiddenSeries": false,
+          "id": 26,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 600,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum (container_memory_working_set_bytes{name!=\"\", namespace=\"kube-system\"})",
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "system services memory",
+              "metric": "container_memory_usage:sort_desc",
+              "range": true,
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "System services memory usage",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:1810",
+              "format": "bytes",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:1811",
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        }
+      ],
       "title": "System services memory usage",
       "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 114
-      },
-      "hiddenSeries": false,
-      "id": 26,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum (container_memory_working_set_bytes{name!=\"\", namespace=\"kube-system\"})",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "system services memory",
-          "metric": "container_memory_usage:sort_desc",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "System services memory usage",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1810",
-          "format": "bytes",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1811",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
+      "collapsed": true,
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -6345,629 +6097,134 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 121
-      },
-      "id": 41,
-      "panels": [],
-      "title": "Containers memory usage",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 122
-      },
-      "hiddenSeries": false,
-      "id": 27,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\", container!=\"\"}) by (container, node, pod, namespace))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "{{node }} ---- {{ namespace }} / {{ pod }}",
-          "metric": "container_memory_usage:sort_desc",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Containers memory usage",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:33",
-          "format": "bytes",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:34",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 129
-      },
-      "id": 42,
-      "panels": [],
-      "title": "All processes memory usage",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 0,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 13,
-        "w": 24,
-        "x": 0,
-        "y": 130
-      },
-      "hiddenSeries": false,
-      "id": 28,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": true,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (container_memory_working_set_bytes{id!=\"\"}) by (id, node, pod, namespace))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }}",
-          "metric": "container_memory_usage:sort_desc",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "All processes memory usage",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1926",
-          "format": "bytes",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1927",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 143
+        "y": 69
       },
       "id": 43,
-      "panels": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "decimals": 2,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 70
+          },
+          "hiddenSeries": false,
+          "id": 16,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 600,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sort_desc (sum (rate (container_network_receive_bytes_total{image!=\"\"}[5m])) by (pod, namespace))",
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "-> pod: {{ namespace }} / {{ pod }}",
+              "metric": "network",
+              "range": true,
+              "refId": "A",
+              "step": 10
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sort_desc (- sum (rate (container_network_transmit_bytes_total{image!=\"\"}[5m])) by (node, pod, namespace))",
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "<- pod: {{ namespace }} / {{ pod }}",
+              "metric": "network",
+              "range": true,
+              "refId": "B",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Pods network I/O (5m avg)",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:2117",
+              "format": "Bps",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:2118",
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        }
+      ],
       "title": "Pods network I/O",
       "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 144
-      },
-      "hiddenSeries": false,
-      "id": 16,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (rate (container_network_receive_bytes_total{image!=\"\"}[5m])) by (pod, namespace))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "-> pod: {{ namespace }} / {{ pod }}",
-          "metric": "network",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (- sum (rate (container_network_transmit_bytes_total{image!=\"\"}[5m])) by (node, pod, namespace))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "<- pod: {{ namespace }} / {{ pod }}",
-          "metric": "network",
-          "range": true,
-          "refId": "B",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Pods network I/O (5m avg)",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:2117",
-          "format": "Bps",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:2118",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 151
-      },
-      "id": 44,
-      "panels": [],
-      "title": "Containers network I/O",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 152
-      },
-      "hiddenSeries": false,
-      "id": 30,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum (rate (container_network_transmit_bytes_total{image!=\"\"}[5m])) by (namespace, pod) ",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "<- pod: {{ namespace }} | {{ pod }}",
-          "metric": "network",
-          "range": true,
-          "refId": "D",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Containers network I/O (5m avg)",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:2253",
-          "format": "Bps",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:2254",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 159
-      },
-      "id": 45,
-      "panels": [],
-      "title": "All processes network I/O",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "decimals": 2,
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {},
-      "gridPos": {
-        "h": 13,
-        "w": 24,
-        "x": 0,
-        "y": 160
-      },
-      "hiddenSeries": false,
-      "id": 29,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sideWidth": 850,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (sum (rate (container_network_receive_bytes_total{id!=\"\"}[5m])) by (id, node, pod, namespace))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "-> pod: {{ namespace }} / pod",
-          "metric": "network",
-          "range": true,
-          "refId": "A",
-          "step": 10
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sort_desc (- sum (rate (container_network_transmit_bytes_total{id!=\"\"}[5m])) by (id, node, pod, namespace))",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "__auto",
-          "metric": "network",
-          "range": true,
-          "refId": "B",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "All processes network I/O (5m avg)",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:2385",
-          "format": "Bps",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:2386",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
     }
   ],
-  "refresh": "5s",
+  "refresh": "30s",
   "schemaVersion": 38,
   "tags": [
     "kubernetes"
@@ -6981,8 +6238,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
-      "10s",
       "30s",
       "1m",
       "5m",
@@ -7007,6 +6262,6 @@
   "timezone": "browser",
   "title": "Kubernetes - Cluster Overall Dashboard",
   "uid": "jcdpwbcia",
-  "version": 17,
+  "version": 26,
   "weekStart": ""
 }

--- a/kubernetes/kubernetes-cluster-overall.json
+++ b/kubernetes/kubernetes-cluster-overall.json
@@ -26,6 +26,7 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 14518,
   "graphTooltip": 0,
+  "id": 13,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -528,7 +529,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -616,7 +617,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -731,9 +732,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "value"
+        "textMode": "value",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "sum(time() - kube_service_created{namespace=\"default\",service=\"kubernetes\"})",
@@ -807,9 +809,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "sum (machine_cpu_cores{})",
@@ -882,15 +885,22 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{id=\"/\"}[5m]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate (container_cpu_usage_seconds_total{container!=\"\"}[5m]))",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -958,9 +968,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "sum (machine_memory_bytes{})",
@@ -1033,14 +1044,21 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "expr": "sum (container_memory_working_set_bytes{id=\"/\"})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(container_memory_working_set_bytes{container!=\"\"})",
           "interval": "10s",
           "intervalFactor": 1,
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -1108,14 +1126,21 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "expr": "sum (container_fs_limit_bytes{device=~\"^/dev/.*$\",id=\"/\"})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (node_filesystem_size_bytes{mountpoint!=\"\"})",
           "interval": "10s",
           "intervalFactor": 1,
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -1183,14 +1208,21 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "expr": "sum (container_fs_usage_bytes{device=~\"^/dev/.*$\",id=\"/\"})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (node_filesystem_size_bytes{mountpoint!=\"\"}) - sum (node_filesystem_avail_bytes{mountpoint!=\"\"})",
           "interval": "10s",
           "intervalFactor": 1,
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -1246,9 +1278,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "sum(kube_pod_status_phase{namespace=~\".*\", phase=\"Running\"})",
@@ -1309,9 +1342,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "sum(kube_pod_status_phase{namespace=~\".*\", phase=\"Pending\"})",
@@ -1381,6 +1415,8 @@
       "links": [],
       "maxDataPoints": 100,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -1392,13 +1428,19 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{id=\"/\"}[5m])) / sum (machine_cpu_cores{}) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate (container_cpu_usage_seconds_total{container!=\"\"}[5m])) / sum (machine_cpu_cores) * 100",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -1461,6 +1503,8 @@
       "links": [],
       "maxDataPoints": 100,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -1472,13 +1516,19 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "expr": "sum (container_memory_working_set_bytes{id=\"/\"}) / sum (machine_memory_bytes{}) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(1 - (\n        (\n          sum (node_memory_MemAvailable_bytes{job=\"node-exporter\"})\n          or\n          sum (\n            (\n              node_memory_Buffers_bytes{job=\"node-exporter\"}\n              +\n              node_memory_Cached_bytes{job=\"node-exporter\"}\n              +\n              node_memory_MemFree_bytes{job=\"node-exporter\"}\n              +\n              node_memory_Slab_bytes{job=\"node-exporter\"}\n            )\n          )\n        )\n      /\n      sum (node_memory_MemTotal_bytes{job=\"node-exporter\"})\n    )) * 100\n",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -1542,6 +1592,8 @@
       "links": [],
       "maxDataPoints": 100,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -1553,15 +1605,21 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "expr": "sum (container_fs_usage_bytes{device=~\"^/dev/.*$\",id=\"/\"}) / sum (container_fs_limit_bytes{device=~\"^/dev/.*$\",id=\"/\"}) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 - (sum (node_filesystem_avail_bytes{mountpoint!=\"\"}) / sum (node_filesystem_size_bytes{mountpoint!=\"\"}) * 100)",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -1616,9 +1674,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "sum(kube_pod_status_phase{namespace=~\".*\", phase=\"Failed\"})",
@@ -1679,16 +1738,23 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "expr": "count(rate(kube_pod_container_status_restarts_total{job=\"kubernetes-service-endpoints\"}[5m]) * 60 * 5 > 0)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "count (rate (kube_pod_container_status_restarts_total{job=\"kube-state-metrics\"}[5m]) * 60 * 5 > 0)",
           "format": "table",
           "interval": "",
           "legendFormat": "",
           "queryType": "randomWalk",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -1734,7 +1800,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 1,
       "points": true,
       "renderer": "flot",
@@ -1849,6 +1915,7 @@
         "displayMode": "gradient",
         "minVizHeight": 10,
         "minVizWidth": 0,
+        "namePlacement": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -1858,9 +1925,10 @@
           "values": false
         },
         "showUnfilled": true,
-        "text": {}
+        "text": {},
+        "valueMode": "color"
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "sum(kube_pod_info{}) by (node)",
@@ -1929,9 +1997,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "count(kube_pod_container_status_terminated_reason{reason!=\"Completed\"} !=0 ) or vector(0)",
@@ -1993,9 +2062,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "count(kube_pod_container_status_waiting !=0 ) or vector(0)",
@@ -2057,9 +2127,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": " count(kube_namespace_created)",
@@ -2121,9 +2192,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "count(kube_persistentvolumeclaim_info) ",
@@ -2174,7 +2246,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 1,
       "points": true,
       "renderer": "flot",
@@ -2184,14 +2256,24 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
           "expr": "sum(kube_pod_container_status_waiting_reason{})",
           "format": "time_series",
           "interval": "",
           "legendFormat": "Total",
           "queryType": "randomWalk",
+          "range": true,
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum(kube_pod_container_status_waiting_reason{} == 1)  by(pod,reason)",
           "format": "time_series",
           "hide": false,
@@ -2280,9 +2362,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "sum(kubelet_running_containers)",
@@ -2344,9 +2427,10 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "sum(kube_pod_status_phase{namespace=~\".*\", phase=\"Unknown\"})",
@@ -2396,7 +2480,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2503,7 +2587,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2513,7 +2597,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (container_memory_working_set_bytes{id=\"/\"}) / sum (machine_memory_bytes{}) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(1 - (\n        (\n          sum (node_memory_MemAvailable_bytes{job=\"node-exporter\"})\n          or\n          sum (\n            (\n              node_memory_Buffers_bytes{job=\"node-exporter\"}\n              +\n              node_memory_Cached_bytes{job=\"node-exporter\"}\n              +\n              node_memory_MemFree_bytes{job=\"node-exporter\"}\n              +\n              node_memory_Slab_bytes{job=\"node-exporter\"}\n            )\n          )\n        )\n      /\n      sum (node_memory_MemTotal_bytes{job=\"node-exporter\"})\n    )) * 100",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2522,11 +2611,17 @@
           "refId": "A"
         },
         {
-          "expr": "sum (container_memory_working_set_bytes{id=\"/\"}) by (node) / sum (machine_memory_bytes) by (node) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(1 - (\n        (\n          sum (node_memory_MemAvailable_bytes{job=\"node-exporter\"}) by (node)\n          or\n          sum (\n            (\n              node_memory_Buffers_bytes{job=\"node-exporter\"}\n              +\n              node_memory_Cached_bytes{job=\"node-exporter\"}\n              +\n              node_memory_MemFree_bytes{job=\"node-exporter\"}\n              +\n              node_memory_Slab_bytes{job=\"node-exporter\"}\n            )\n          ) by (node)\n        )\n      /\n      sum (node_memory_MemTotal_bytes{job=\"node-exporter\"}) by (node)\n    )) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
           "legendFormat": "{{node}}",
+          "range": true,
           "refId": "B"
         }
       ],
@@ -2600,7 +2695,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2610,7 +2705,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (container_fs_usage_bytes{device=~\"^/dev/.*$\",id=\"/\"}) / sum (container_fs_limit_bytes{device=~\"^/dev/.*$\",id=\"/\"}) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 - (sum (node_filesystem_avail_bytes{mountpoint!=\"\"}) / sum (node_filesystem_size_bytes{mountpoint!=\"\"}) * 100)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2619,11 +2719,17 @@
           "refId": "A"
         },
         {
-          "expr": "sum (container_fs_usage_bytes{device=~\"^/dev/.*$\",id=\"/\"}) by (node) / sum (container_fs_limit_bytes{device=~\"^/dev/.*$\",id=\"/\"}) by (node) * 100",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 - (sum (node_filesystem_avail_bytes{mountpoint!=\"\"}) by (node) / sum (node_filesystem_size_bytes{mountpoint!=\"\"}) by (node) * 100)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
           "legendFormat": "{{node}}",
+          "range": true,
           "refId": "B"
         }
       ],
@@ -2695,7 +2801,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2705,7 +2811,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{id=\"/\"}[5m])) / sum (machine_cpu_cores{})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate (container_cpu_usage_seconds_total{container!=\"\"}[5m])) / sum (machine_cpu_cores)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2715,11 +2826,17 @@
           "refId": "A"
         },
         {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{id=\"/\"}[5m])) by (node) / sum (machine_cpu_cores) by (node)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate (container_cpu_usage_seconds_total{container!=\"\"}[5m])) by (node) / sum (machine_cpu_cores) by (node)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
           "legendFormat": "{{node}}",
+          "range": true,
           "refId": "B"
         }
       ],
@@ -2952,6 +3069,11 @@
       ],
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
           "expr": "sum(kube_pod_owner{}) by (namespace)",
           "format": "table",
           "instant": true,
@@ -2962,6 +3084,11 @@
           "step": 10
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
           "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{}) by (workload, namespace)) by (namespace)",
           "format": "table",
           "instant": true,
@@ -2972,6 +3099,11 @@
           "step": 10
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
           "expr": "sum(container_memory_rss{container!=\"\"}) by (namespace)",
           "format": "table",
           "instant": true,
@@ -2981,6 +3113,11 @@
           "step": 10
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
           "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"}) by (namespace)",
           "format": "table",
           "instant": true,
@@ -2990,6 +3127,10 @@
           "step": 10
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum(container_memory_rss{container!=\"\"}) by (namespace) / sum(kube_pod_container_resource_requests{resource=\"memory\"}) by (namespace)",
           "format": "table",
           "instant": true,
@@ -3000,6 +3141,10 @@
           "step": 10
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"}) by (namespace)",
           "format": "table",
           "instant": true,
@@ -3009,6 +3154,11 @@
           "step": 10
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
           "expr": "sum(container_memory_rss{container!=\"\"}) by (namespace) / sum(kube_pod_container_resource_limits{resource=\"memory\"}) by (namespace)",
           "format": "table",
           "instant": true,
@@ -3336,15 +3486,17 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 57
+            "y": 16
           },
           "hiddenSeries": false,
           "id": 2058,
           "legend": {
+            "alignAsTable": true,
             "avg": false,
             "current": false,
             "max": false,
             "min": false,
+            "rightSide": true,
             "show": true,
             "total": false,
             "values": false
@@ -3357,7 +3509,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -3372,11 +3524,17 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\"}) by (pod_name)",
-              "format": "table",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\"}) by (node, pod, namespace))",
+              "format": "time_series",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "{{ node }} ---- {{ namespace }} / {{ pod }}",
               "queryType": "randomWalk",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -3437,8 +3595,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "#299c46",
-                    "value": null
+                    "color": "#299c46"
                   },
                   {
                     "color": "rgba(237, 129, 40, 0.89)",
@@ -3457,7 +3614,7 @@
             "h": 3,
             "w": 4,
             "x": 12,
-            "y": 57
+            "y": 16
           },
           "id": 2056,
           "links": [],
@@ -3474,9 +3631,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_node_status_condition{condition=\"DiskPressure\", status!=\"false\"})",
@@ -3514,8 +3672,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "#299c46",
-                    "value": null
+                    "color": "#299c46"
                   },
                   {
                     "color": "rgba(237, 129, 40, 0.89)",
@@ -3534,7 +3691,7 @@
             "h": 3,
             "w": 4,
             "x": 16,
-            "y": 57
+            "y": 16
           },
           "id": 2059,
           "links": [],
@@ -3551,9 +3708,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_node_status_condition{condition=\"MemoryPressure\", status!=\"false\"})",
@@ -3591,8 +3749,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "#299c46",
-                    "value": null
+                    "color": "#299c46"
                   },
                   {
                     "color": "rgba(237, 129, 40, 0.89)",
@@ -3611,7 +3768,7 @@
             "h": 3,
             "w": 4,
             "x": 20,
-            "y": 57
+            "y": 16
           },
           "id": 2061,
           "links": [],
@@ -3628,9 +3785,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_node_status_condition{condition=\"PIDPressure\", status!=\"false\"})",
@@ -3668,8 +3826,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "#299c46",
-                    "value": null
+                    "color": "#299c46"
                   },
                   {
                     "color": "rgba(237, 129, 40, 0.89)",
@@ -3688,7 +3845,7 @@
             "h": 3,
             "w": 4,
             "x": 12,
-            "y": 60
+            "y": 19
           },
           "id": 2026,
           "links": [],
@@ -3705,9 +3862,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_node_spec_unschedulable{})",
@@ -3745,8 +3903,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "#299c46",
-                    "value": null
+                    "color": "#299c46"
                   },
                   {
                     "color": "rgba(237, 129, 40, 0.89)",
@@ -3765,7 +3922,7 @@
             "h": 3,
             "w": 4,
             "x": 16,
-            "y": 60
+            "y": 19
           },
           "id": 2025,
           "links": [],
@@ -3782,9 +3939,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_node_status_condition{condition=\"OutOfDisk\", status=\"true\"})",
@@ -3822,8 +3980,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "#299c46",
-                    "value": null
+                    "color": "#299c46"
                   },
                   {
                     "color": "rgba(237, 129, 40, 0.89)",
@@ -3842,7 +3999,7 @@
             "h": 3,
             "w": 4,
             "x": 20,
-            "y": 60
+            "y": 19
           },
           "id": 2060,
           "links": [],
@@ -3859,9 +4016,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_node_status_condition{condition=\"NetworkUnavailable\", status!=\"false\"})",
@@ -3907,7 +4065,7 @@
             "h": 5,
             "w": 6,
             "x": 0,
-            "y": 58
+            "y": 17
           },
           "id": 2016,
           "links": [],
@@ -4005,8 +4163,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4022,7 +4179,7 @@
             "h": 5,
             "w": 6,
             "x": 6,
-            "y": 58
+            "y": 17
           },
           "id": 2018,
           "links": [],
@@ -4039,9 +4196,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_deployment_status_replicas{namespace=~\".*\"})",
@@ -4080,8 +4238,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4097,7 +4254,7 @@
             "h": 5,
             "w": 6,
             "x": 12,
-            "y": 58
+            "y": 17
           },
           "id": 2019,
           "links": [],
@@ -4114,9 +4271,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_deployment_status_replicas_updated{namespace=~\".*\"})",
@@ -4153,8 +4311,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4170,7 +4327,7 @@
             "h": 5,
             "w": 6,
             "x": 18,
-            "y": 58
+            "y": 17
           },
           "id": 2020,
           "links": [],
@@ -4187,9 +4344,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_deployment_status_replicas_unavailable{namespace=~\".*\"})",
@@ -4245,8 +4403,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4262,7 +4419,7 @@
             "h": 3,
             "w": 8,
             "x": 0,
-            "y": 59
+            "y": 18
           },
           "id": 2047,
           "links": [],
@@ -4279,9 +4436,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_job_status_succeeded{namespace=~\".*\"})",
@@ -4319,8 +4477,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4336,7 +4493,7 @@
             "h": 3,
             "w": 8,
             "x": 8,
-            "y": 59
+            "y": 18
           },
           "id": 2048,
           "links": [],
@@ -4353,9 +4510,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_job_status_active{namespace=~\".*\"})",
@@ -4393,8 +4551,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4410,7 +4567,7 @@
             "h": 3,
             "w": 8,
             "x": 16,
-            "y": 59
+            "y": 18
           },
           "id": 2049,
           "links": [],
@@ -4427,9 +4584,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_job_status_failed{namespace=~\".*\"})",
@@ -4485,8 +4643,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4502,7 +4659,7 @@
             "h": 3,
             "w": 12,
             "x": 0,
-            "y": 60
+            "y": 19
           },
           "id": 2030,
           "links": [],
@@ -4519,9 +4676,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_pod_status_phase{namespace=~\".*\", phase=\"Running\"})",
@@ -4560,8 +4718,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4577,7 +4734,7 @@
             "h": 3,
             "w": 12,
             "x": 12,
-            "y": 60
+            "y": 19
           },
           "id": 2031,
           "links": [],
@@ -4594,9 +4751,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_pod_status_phase{namespace=~\".*\", phase=\"Pending\"})",
@@ -4636,8 +4794,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4653,7 +4810,7 @@
             "h": 3,
             "w": 6,
             "x": 0,
-            "y": 63
+            "y": 22
           },
           "id": 2033,
           "links": [],
@@ -4670,9 +4827,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_pod_status_phase{namespace=~\".*\", phase=\"Succeeded\"})",
@@ -4711,8 +4869,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4728,7 +4885,7 @@
             "h": 3,
             "w": 10,
             "x": 6,
-            "y": 63
+            "y": 22
           },
           "id": 2032,
           "links": [],
@@ -4745,9 +4902,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_pod_status_phase{namespace=~\".*\", phase=\"Failed\"})",
@@ -4787,8 +4945,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4804,7 +4961,7 @@
             "h": 3,
             "w": 8,
             "x": 16,
-            "y": 63
+            "y": 22
           },
           "id": 2034,
           "links": [],
@@ -4821,9 +4978,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_pod_status_phase{namespace=~\".*\", phase=\"Unknown\"})",
@@ -4880,8 +5038,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4897,7 +5054,7 @@
             "h": 3,
             "w": 6,
             "x": 0,
-            "y": 61
+            "y": 20
           },
           "id": 2038,
           "links": [],
@@ -4914,9 +5071,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_pod_container_status_running{namespace=~\".*\"})",
@@ -4954,8 +5112,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4971,7 +5128,7 @@
             "h": 3,
             "w": 6,
             "x": 6,
-            "y": 61
+            "y": 20
           },
           "id": 2039,
           "links": [],
@@ -4988,9 +5145,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_pod_container_status_waiting{namespace=~\".*\"})",
@@ -5028,8 +5186,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5045,7 +5202,7 @@
             "h": 3,
             "w": 6,
             "x": 12,
-            "y": 61
+            "y": 20
           },
           "id": 2040,
           "links": [],
@@ -5062,9 +5219,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(kube_pod_container_status_terminated{namespace=~\".*\"})",
@@ -5102,8 +5260,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5119,7 +5276,7 @@
             "h": 3,
             "w": 6,
             "x": 18,
-            "y": 61
+            "y": 20
           },
           "id": 2041,
           "links": [],
@@ -5136,9 +5293,10 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
               "expr": "sum(delta(kube_pod_container_status_restarts{namespace=~\".*\"}[30m]))",
@@ -5176,8 +5334,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5193,7 +5350,7 @@
             "h": 3,
             "w": 12,
             "x": 0,
-            "y": 64
+            "y": 23
           },
           "id": 2043,
           "links": [],
@@ -5210,14 +5367,21 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
-              "expr": "sum(kube_pod_container_resource_requests_cpu_cores{namespace=~\".*\"})",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=~\".*\"})",
               "format": "time_series",
               "intervalFactor": 1,
+              "range": true,
               "refId": "A"
             }
           ],
@@ -5250,8 +5414,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -5267,7 +5430,7 @@
             "h": 3,
             "w": 12,
             "x": 12,
-            "y": 64
+            "y": 23
           },
           "id": 2042,
           "links": [],
@@ -5284,14 +5447,21 @@
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "10.2.2",
           "targets": [
             {
-              "expr": "sum(kube_pod_container_resource_requests_memory_bytes{namespace=~\".*\"})",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=~\".*\"})",
               "format": "time_series",
               "intervalFactor": 1,
+              "range": true,
               "refId": "A"
             }
           ],
@@ -5300,248 +5470,6 @@
         }
       ],
       "title": "Containers",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 61
-      },
-      "id": 33,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "decimals": 2,
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "fillGradient": 0,
-          "grid": {},
-          "gridPos": {
-            "h": 5,
-            "w": 24,
-            "x": 0,
-            "y": 62
-          },
-          "height": "200px",
-          "hiddenSeries": false,
-          "id": 32,
-          "isNew": true,
-          "legend": {
-            "alignAsTable": false,
-            "avg": true,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": false,
-            "sideWidth": 200,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "nullPointMode": "connected",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.5.3",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum (rate (container_network_receive_bytes_total{}[5m]))",
-              "format": "time_series",
-              "interval": "10s",
-              "intervalFactor": 1,
-              "legendFormat": "Received",
-              "metric": "network",
-              "refId": "A",
-              "step": 10
-            },
-            {
-              "expr": "- sum (rate (container_network_transmit_bytes_total{}[5m]))",
-              "format": "time_series",
-              "interval": "10s",
-              "intervalFactor": 1,
-              "legendFormat": "Sent",
-              "metric": "network",
-              "refId": "B",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Network I/O pressure",
-          "tooltip": {
-            "msResolution": false,
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "Bps",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "Bps",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
-      "title": "Network I/O pressure",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 62
-      },
-      "id": 35,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "decimals": 3,
-          "editable": true,
-          "error": false,
-          "fill": 0,
-          "fillGradient": 0,
-          "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 63
-          },
-          "height": "",
-          "hiddenSeries": false,
-          "id": 17,
-          "isNew": true,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "nullPointMode": "connected",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.5.3",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": true,
-          "targets": [
-            {
-              "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\"}[5m])) by (pod_name)",
-              "format": "time_series",
-              "interval": "10s",
-              "intervalFactor": 1,
-              "legendFormat": "{{ pod_name }}",
-              "metric": "container_cpu",
-              "refId": "A",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Pods CPU usage (5m avg)",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "sort": 2,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "percentunit",
-              "label": "cores",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
-      "title": "Pods CPU usage",
       "type": "row"
     },
     {
@@ -5554,7 +5482,256 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 63
+        "y": 61
+      },
+      "id": 33,
+      "panels": [],
+      "title": "Network I/O pressure",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "height": "200px",
+      "hiddenSeries": false,
+      "id": 32,
+      "legend": {
+        "alignAsTable": false,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": false,
+        "sideWidth": 200,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.2.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum (rate (container_network_receive_bytes_total{}[5m]))",
+          "format": "time_series",
+          "interval": "10s",
+          "intervalFactor": 1,
+          "legendFormat": "Received",
+          "metric": "network",
+          "refId": "A",
+          "step": 10
+        },
+        {
+          "expr": "- sum (rate (container_network_transmit_bytes_total{}[5m]))",
+          "format": "time_series",
+          "interval": "10s",
+          "intervalFactor": 1,
+          "legendFormat": "Sent",
+          "metric": "network",
+          "refId": "B",
+          "step": 10
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Network I/O pressure (5m avg)",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:943",
+          "format": "Bps",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:944",
+          "format": "Bps",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 67
+      },
+      "id": 35,
+      "panels": [],
+      "title": "Pods CPU usage",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "decimals": 3,
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 68
+      },
+      "height": "",
+      "hiddenSeries": false,
+      "id": 17,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 850,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.2.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=\"\"}[5m])) by (node, pod, namespace))",
+          "format": "time_series",
+          "interval": "10s",
+          "intervalFactor": 1,
+          "legendFormat": "{{ node }} ----{{ namespace }} / {{ pod }}",
+          "metric": "container_cpu",
+          "range": true,
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Pods CPU usage (5m avg)",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 2,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1205",
+          "format": "percentunit",
+          "label": "cores",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1206",
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 75
       },
       "id": 36,
       "panels": [],
@@ -5580,12 +5757,11 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 64
+        "y": 76
       },
       "height": "",
       "hiddenSeries": false,
       "id": 23,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -5594,6 +5770,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -5607,7 +5784,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -5621,13 +5798,15 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "editorMode": "code",
           "expr": "sum (rate (container_cpu_usage_seconds_total{name!=\"\", namespace=\"kube-system\"}[5m]))",
           "format": "time_series",
           "hide": false,
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "{{ systemd_service_name }}",
+          "legendFormat": "system services cpu",
           "metric": "container_cpu",
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -5649,12 +5828,14 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1262",
           "format": "percentunit",
           "label": "cores",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:1263",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -5674,7 +5855,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 71
+        "y": 83
       },
       "id": 37,
       "panels": [],
@@ -5700,12 +5881,11 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 72
+        "y": 84
       },
       "height": "",
       "hiddenSeries": false,
       "id": 24,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -5716,6 +5896,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -5729,7 +5910,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -5739,35 +5920,20 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",container_name!=\"POD\"}[5m])) by (container_name, pod_name)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=\"\", container!=\"\"}[5m])) by (node, pod, namespace))",
           "format": "time_series",
           "hide": false,
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "pod: {{ pod_name }} | {{ container_name }}",
+          "legendFormat": "{{ node }} ---- {{ namespace }} / {{ pod }}",
           "metric": "container_cpu",
+          "range": true,
           "refId": "A",
-          "step": 10
-        },
-        {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name!~\"^k8s_.*\"}[5m])) by (node, name, image)",
-          "format": "time_series",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "docker: {{ node }} | {{ image }} ({{ name }})",
-          "metric": "container_cpu",
-          "refId": "B",
-          "step": 10
-        },
-        {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{rkt_container_name!=\"\"}[5m])) by (node, rkt_container_name)",
-          "format": "time_series",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "rkt: {{ node }} | {{ rkt_container_name }}",
-          "metric": "container_cpu",
-          "refId": "C",
           "step": 10
         }
       ],
@@ -5788,12 +5954,14 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1398",
           "format": "percentunit",
           "label": "cores",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:1399",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -5802,237 +5970,6 @@
       "yaxis": {
         "align": false
       }
-    },
-    {
-      "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 79
-      },
-      "id": 38,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "decimals": 3,
-          "editable": true,
-          "error": false,
-          "fill": 0,
-          "fillGradient": 0,
-          "grid": {},
-          "gridPos": {
-            "h": 13,
-            "w": 24,
-            "x": 0,
-            "y": 66
-          },
-          "hiddenSeries": false,
-          "id": 20,
-          "isNew": true,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "nullPointMode": "connected",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.5.3",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": true,
-          "targets": [
-            {
-              "expr": "sum (rate (container_cpu_usage_seconds_total{id!=\"/\"}[5m])) by (id)",
-              "format": "time_series",
-              "hide": false,
-              "interval": "10s",
-              "intervalFactor": 1,
-              "legendFormat": "{{ id }}",
-              "metric": "container_cpu",
-              "refId": "A",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "All processes CPU usage (5m avg)",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "sort": 2,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "percentunit",
-              "label": "cores",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
-      "title": "All processes CPU usage",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 80
-      },
-      "id": 39,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "decimals": 2,
-          "editable": true,
-          "error": false,
-          "fill": 0,
-          "fillGradient": 0,
-          "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 67
-          },
-          "hiddenSeries": false,
-          "id": 25,
-          "isNew": true,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": 200,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "nullPointMode": "connected",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.5.3",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": true,
-          "targets": [
-            {
-              "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\"}) by (pod_name)",
-              "format": "time_series",
-              "interval": "10s",
-              "intervalFactor": 1,
-              "legendFormat": "{{ pod_name }}",
-              "metric": "container_memory_usage:sort_desc",
-              "refId": "A",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Pods memory usage",
-          "tooltip": {
-            "msResolution": false,
-            "shared": true,
-            "sort": 2,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
-      "title": "Pods memory usage",
-      "type": "row"
     },
     {
       "collapsed": false,
@@ -6044,7 +5981,251 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 81
+        "y": 91
+      },
+      "id": 38,
+      "panels": [],
+      "title": "All processes CPU usage",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "decimals": 3,
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 92
+      },
+      "hiddenSeries": false,
+      "id": 20,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 850,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.2.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (rate (container_cpu_usage_seconds_total{id!=\"\"}[5m])) by (id, node, pod, namespace))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "10s",
+          "intervalFactor": 1,
+          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }}",
+          "metric": "container_cpu",
+          "range": true,
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "All processes CPU usage (5m avg)",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 2,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1609",
+          "format": "percentunit",
+          "label": "cores",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1610",
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 105
+      },
+      "id": 39,
+      "panels": [],
+      "title": "Pods memory usage",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 106
+      },
+      "hiddenSeries": false,
+      "id": 25,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 850,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.2.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\"}) by (node, pod, namespace))",
+          "format": "time_series",
+          "interval": "10s",
+          "intervalFactor": 1,
+          "legendFormat": "{{ node }} ---- {{ namespace }} / {{ pod }}",
+          "metric": "container_memory_usage:sort_desc",
+          "range": true,
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Pods memory usage",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 2,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1745",
+          "format": "bytes",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1746",
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 113
       },
       "id": 40,
       "panels": [],
@@ -6070,11 +6251,10 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 82
+        "y": 114
       },
       "hiddenSeries": false,
       "id": 26,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -6083,7 +6263,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sideWidth": 200,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -6097,7 +6277,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -6111,11 +6291,13 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "editorMode": "code",
           "expr": "sum (container_memory_working_set_bytes{name!=\"\", namespace=\"kube-system\"})",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "{{ systemd_service_name }}",
+          "legendFormat": "system services memory",
           "metric": "container_memory_usage:sort_desc",
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -6137,11 +6319,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1810",
           "format": "bytes",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:1811",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -6161,7 +6345,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 89
+        "y": 121
       },
       "id": 41,
       "panels": [],
@@ -6187,11 +6371,10 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 90
+        "y": 122
       },
       "hiddenSeries": false,
       "id": 27,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -6200,7 +6383,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sideWidth": 200,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -6214,7 +6397,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -6224,30 +6407,18 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",container_name!=\"POD\"}) by (container_name, pod_name)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (container_memory_working_set_bytes{image!=\"\", container!=\"\"}) by (container, node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "pod: {{ pod_name }} | {{ container_name }}",
+          "legendFormat": "{{node }} ---- {{ namespace }} / {{ pod }}",
           "metric": "container_memory_usage:sort_desc",
+          "range": true,
           "refId": "A",
-          "step": 10
-        },
-        {
-          "expr": "sum (container_memory_working_set_bytes{image!=\"\",name!~\"^k8s_.*\"}) by (node, name, image)",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "docker: {{ node }} | {{ image }} ({{ name }})",
-          "metric": "container_memory_usage:sort_desc",
-          "refId": "B",
-          "step": 10
-        },
-        {
-          "expr": "sum (container_memory_working_set_bytes{rkt_container_name!=\"\"}) by (node, rkt_container_name)",
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "rkt: {{ node }} | {{ rkt_container_name }}",
-          "metric": "container_memory_usage:sort_desc",
-          "refId": "C",
           "step": 10
         }
       ],
@@ -6268,11 +6439,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:33",
           "format": "bytes",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:34",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -6292,7 +6465,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 97
+        "y": 129
       },
       "id": 42,
       "panels": [],
@@ -6318,20 +6491,19 @@
         "h": 13,
         "w": 24,
         "x": 0,
-        "y": 98
+        "y": 130
       },
       "hiddenSeries": false,
       "id": 28,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
         "current": true,
         "max": false,
         "min": false,
-        "rightSide": false,
+        "rightSide": true,
         "show": true,
-        "sideWidth": 200,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -6345,7 +6517,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -6355,11 +6527,17 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum (container_memory_working_set_bytes{id!=\"/\"}) by (id)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (container_memory_working_set_bytes{id!=\"\"}) by (id, node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "{{ id }}",
+          "legendFormat": "{{ node }}  ---- {{ namespace }} / {{ pod }}",
           "metric": "container_memory_usage:sort_desc",
+          "range": true,
           "refId": "A",
           "step": 10
         }
@@ -6381,11 +6559,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1926",
           "format": "bytes",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:1927",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -6405,7 +6585,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 111
+        "y": 143
       },
       "id": 43,
       "panels": [],
@@ -6431,11 +6611,10 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 112
+        "y": 144
       },
       "hiddenSeries": false,
       "id": 16,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -6444,7 +6623,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sideWidth": 200,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -6458,7 +6637,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -6468,20 +6647,32 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name=~\"^k8s_.*\"}[5m])) by (pod_name)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (rate (container_network_receive_bytes_total{image!=\"\"}[5m])) by (pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "-> {{ pod_name }}",
+          "legendFormat": "-> pod: {{ namespace }} / {{ pod }}",
           "metric": "network",
+          "range": true,
           "refId": "A",
           "step": 10
         },
         {
-          "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name=~\"^k8s_.*\"}[5m])) by (pod_name)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (- sum (rate (container_network_transmit_bytes_total{image!=\"\"}[5m])) by (node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "<- {{ pod_name }}",
+          "legendFormat": "<- pod: {{ namespace }} / {{ pod }}",
           "metric": "network",
+          "range": true,
           "refId": "B",
           "step": 10
         }
@@ -6503,11 +6694,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:2117",
           "format": "Bps",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:2118",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -6527,7 +6720,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 119
+        "y": 151
       },
       "id": 44,
       "panels": [],
@@ -6553,11 +6746,10 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 120
+        "y": 152
       },
       "hiddenSeries": false,
       "id": 30,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -6566,7 +6758,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sideWidth": 200,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -6580,7 +6772,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -6590,63 +6782,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name=~\"^k8s_.*\"}[5m])) by (container_name, pod_name)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate (container_network_transmit_bytes_total{image!=\"\"}[5m])) by (namespace, pod) ",
           "hide": false,
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "-> pod: {{ pod_name }} | {{ container_name }}",
+          "legendFormat": "<- pod: {{ namespace }} | {{ pod }}",
           "metric": "network",
-          "refId": "B",
-          "step": 10
-        },
-        {
-          "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name=~\"^k8s_.*\"}[5m])) by (container_name, pod_name)",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "<- pod: {{ pod_name }} | {{ container_name }}",
-          "metric": "network",
+          "range": true,
           "refId": "D",
-          "step": 10
-        },
-        {
-          "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name!~\"^k8s_.*\"}[5m])) by (node, name, image)",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "-> docker: {{ node }} | {{ image }} ({{ name }})",
-          "metric": "network",
-          "refId": "A",
-          "step": 10
-        },
-        {
-          "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name!~\"^k8s_.*\"}[5m])) by (node, name, image)",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "<- docker: {{ node }} | {{ image }} ({{ name }})",
-          "metric": "network",
-          "refId": "C",
-          "step": 10
-        },
-        {
-          "expr": "sum (rate (container_network_transmit_bytes_total{rkt_container_name!=\"\"}[5m])) by (node, rkt_container_name)",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "-> rkt: {{ node }} | {{ rkt_container_name }}",
-          "metric": "network",
-          "refId": "E",
-          "step": 10
-        },
-        {
-          "expr": "- sum (rate (container_network_transmit_bytes_total{rkt_container_name!=\"\"}[5m])) by (node, rkt_container_name)",
-          "hide": false,
-          "interval": "10s",
-          "intervalFactor": 1,
-          "legendFormat": "<- rkt: {{ node }} | {{ rkt_container_name }}",
-          "metric": "network",
-          "refId": "F",
           "step": 10
         }
       ],
@@ -6667,11 +6815,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:2253",
           "format": "Bps",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:2254",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -6691,7 +6841,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 127
+        "y": 159
       },
       "id": 45,
       "panels": [],
@@ -6717,20 +6867,19 @@
         "h": 13,
         "w": 24,
         "x": 0,
-        "y": 128
+        "y": 160
       },
       "hiddenSeries": false,
       "id": 29,
-      "isNew": true,
       "legend": {
         "alignAsTable": true,
         "avg": true,
         "current": true,
         "max": false,
         "min": false,
-        "rightSide": false,
+        "rightSide": true,
         "show": true,
-        "sideWidth": 200,
+        "sideWidth": 850,
         "sort": "current",
         "sortDesc": true,
         "total": false,
@@ -6744,7 +6893,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -6754,20 +6903,32 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate (container_network_receive_bytes_total{id!=\"/\"}[5m])) by (id)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (sum (rate (container_network_receive_bytes_total{id!=\"\"}[5m])) by (id, node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "-> {{ id }}",
+          "legendFormat": "-> pod: {{ namespace }} / pod",
           "metric": "network",
+          "range": true,
           "refId": "A",
           "step": 10
         },
         {
-          "expr": "- sum (rate (container_network_transmit_bytes_total{id!=\"/\"}[5m])) by (id)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc (- sum (rate (container_network_transmit_bytes_total{id!=\"\"}[5m])) by (id, node, pod, namespace))",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "<- {{ id }}",
+          "legendFormat": "__auto",
           "metric": "network",
+          "range": true,
           "refId": "B",
           "step": 10
         }
@@ -6789,11 +6950,13 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:2385",
           "format": "Bps",
           "logBase": 1,
           "show": true
         },
         {
+          "$$hashKey": "object:2386",
           "format": "short",
           "logBase": 1,
           "show": false
@@ -6805,8 +6968,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 36,
-  "style": "dark",
+  "schemaVersion": 38,
   "tags": [
     "kubernetes"
   ],
@@ -6845,6 +7007,6 @@
   "timezone": "browser",
   "title": "Kubernetes - Cluster Overall Dashboard",
   "uid": "jcdpwbcia",
-  "version": 1,
+  "version": 17,
   "weekStart": ""
 }


### PR DESCRIPTION
### Summary

JIRA: <https://saritasa.atlassian.net/browse/USAWS-20>

Fixed [Kubernetes - Cluster Overall](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s>) grafana dashboard configuration.

i edited url for `Kubernetes - Cluster Overall` dashboard:
<https://github.com/saritasa-nest/usummit-kubernetes-aws/blob/feature/fix-grafana-dashboards/config/addons/monitoring/prometheus/values.yaml#L362>

Edited:
- [Cluster Total Usage - CPU Used](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&editPanel=11>)
```bash
sum (rate (container_cpu_usage_seconds_total{id="/"}[5m]))
```
to
```bash
sum (rate (container_cpu_usage_seconds_total{container!=""}[5m]))
```
- [Cluster Total Usage - CPU Usage](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&editPanel=6>)
```bash
sum (rate (container_cpu_usage_seconds_total{id="/"}[5m])) / sum (machine_cpu_cores{}) * 100
```
to
```bash
sum (rate (container_cpu_usage_seconds_total{container!=""}[5m])) / sum (machine_cpu_cores) * 100
```
- [Cluster Total Usage - Mem Used](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&editPanel=9>)
```bash
sum (container_memory_working_set_bytes{id="/"})
```
to
```bash
sum(container_memory_working_set_bytes{container!=""})
```
- [Cluster Total Usage - Memory Usage](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&editPanel=4>)
```bash
sum (container_memory_working_set_bytes{id="/"}) / sum (machine_memory_bytes{}) * 100
```
to
```bash
(1 - (
        (
          sum (node_memory_MemAvailable_bytes{job="node-exporter"})
          or
          sum (
            (
              node_memory_Buffers_bytes{job="node-exporter"}
              +
              node_memory_Cached_bytes{job="node-exporter"}
              +
              node_memory_MemFree_bytes{job="node-exporter"}
              +
              node_memory_Slab_bytes{job="node-exporter"}
            )
          )
        )
      /
      sum (node_memory_MemTotal_bytes{job="node-exporter"})
    )) * 100
```
- [Cluster Total Usage - Disk Total](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&editPanel=14>)
```bash
sum (container_fs_limit_bytes{device=~"^/dev/.*$",id="/"})
```
to
```bash
sum (node_filesystem_size_bytes{mountpoint!=""})
```
- [Cluster Total Usage - Disk Used](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&editPanel=13>)
```bash
sum (container_fs_usage_bytes{device=~"^/dev/.*$",id="/"})
```
to
```bash
sum (node_filesystem_size_bytes{mountpoint!=""}) - sum (node_filesystem_avail_bytes{mountpoint!=""})
```
- [Cluster Total Usage - Filesystem Usage](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&editPanel=7>)
```bash
sum (container_fs_usage_bytes{device=~"^/dev/.*$",id="/"}) / sum (container_fs_limit_bytes{device=~"^/dev/.*$",id="/"}) * 100
```
to
```bash
100 - (sum (node_filesystem_avail_bytes{mountpoint!=""}) / sum (node_filesystem_size_bytes{mountpoint!=""}) * 100)
```
- [Cluster Total Usage - Pod Crash Looping](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&editPanel=2069>)
```bash
count(rate(kube_pod_container_status_restarts_total{job="kubernetes-service-endpoints"}[5m]) * 60 * 5 > 0)
```
to
```bash
count (rate (kube_pod_container_status_restarts_total{job="kube-state-metrics"}[5m]) * 60 * 5 > 0)
```
- [Cluster Total Usage - Memory Usage](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&viewPanel=2052&editPanel=2052>)

**A**
```bash
sum (container_memory_working_set_bytes{id="/"}) / sum (machine_memory_bytes{}) * 100
```
to
```bash
(1 - (
        (
          sum (node_memory_MemAvailable_bytes{job="node-exporter"})
          or
          sum (
            (
              node_memory_Buffers_bytes{job="node-exporter"}
              +
              node_memory_Cached_bytes{job="node-exporter"}
              +
              node_memory_MemFree_bytes{job="node-exporter"}
              +
              node_memory_Slab_bytes{job="node-exporter"}
            )
          )
        )
      /
      sum (node_memory_MemTotal_bytes{job="node-exporter"})
    )) * 100
```
**B**
```bash
sum (container_memory_working_set_bytes{id="/"}) by (node) / sum (machine_memory_bytes) by (node) * 100
```
to
```bash
(1 - (
        (
          sum (node_memory_MemAvailable_bytes{job="node-exporter"}) by (node)
          or
          sum (
            (
              node_memory_Buffers_bytes{job="node-exporter"}
              +
              node_memory_Cached_bytes{job="node-exporter"}
              +
              node_memory_MemFree_bytes{job="node-exporter"}
              +
              node_memory_Slab_bytes{job="node-exporter"}
            )
          ) by (node)
        )
      /
      sum (node_memory_MemTotal_bytes{job="node-exporter"}) by (node)
    )) * 100
```
- [Cluster Total Usage - Filesystem Usage](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&editPanel=2053>)

**A**
```bash
sum (container_fs_usage_bytes{device=~"^/dev/.*$",id="/"}) / sum (container_fs_limit_bytes{device=~"^/dev/.*$",id="/"}) * 100
```
to
```bash
100 - (sum (node_filesystem_avail_bytes{mountpoint!=""}) / sum (node_filesystem_size_bytes{mountpoint!=""}) * 100)
```
**B**
```bash
sum (container_fs_usage_bytes{device=~"^/dev/.*$",id="/"}) by (node) / sum (container_fs_limit_bytes{device=~"^/dev/.*$",id="/"}) by (node) * 100
```
to
```
100 - (sum (node_filesystem_avail_bytes{mountpoint!=""}) by (node) / sum (node_filesystem_size_bytes{mountpoint!=""}) by (node) * 100)
```
- [Cluster Total Usage - CPU Usage](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&editPanel=2051>)

**A**
```bash
sum (rate (container_cpu_usage_seconds_total{id="/"}[5m])) / sum (machine_cpu_cores{})
```
to
```bash
sum (rate (container_cpu_usage_seconds_total{container!=""}[5m])) / sum (machine_cpu_cores) * 100
```
**B**
```bash
sum (rate (container_cpu_usage_seconds_total{id="/"}[5m])) by (node) / sum (machine_cpu_cores) by (node)
```
to
```bash
sum (rate (container_cpu_usage_seconds_total{container!=""}[5m])) by (node) / sum (machine_cpu_cores) by (node)
```
- [Node - Pod Memory Usage](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&editPanel=2058>)
```bash
sum (container_memory_working_set_bytes{image!="",name=~"^k8s_.*"}) by (pod_name)
```
to
```bash
sort_desc (sum (container_memory_working_set_bytes{image!=""}) by (pod, namespace))
```
- [Containers - CPU Cores Requested by Containers](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&from=now-2d&to=now&editPanel=2043>)
```bash
sum(kube_pod_container_resource_requests_cpu_cores{namespace=~".*"})
```
to
```bash
sum(kube_pod_container_resource_requests{resource="cpu", namespace=~".*"})
```
- [Containers - Memory Requested By Containers](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&from=now-2d&to=now&editPanel=2042>)
```bash
sum(kube_pod_container_resource_requests_memory_bytes{namespace=~".*"})
```
to
```bash
sum(kube_pod_container_resource_requests{resource="memory", namespace=~".*"})
```
- [Pods CPU usage](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&editPanel=17>)
```bash
sum (rate (container_cpu_usage_seconds_total{image!="",name=~"^k8s_.*"}[5m])) by (pod_name)
```
to
```bash
sort_desc (sum (rate (container_cpu_usage_seconds_total{image!=""}[5m])) by (pod, namespace))
```
- [Pods memory usage](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&editPanel=25>)
```bash
sum (container_memory_working_set_bytes{image!="",name=~"^k8s_.*"}) by (pod_name)
```
to
```bash
sort_desc (sum (container_memory_working_set_bytes{image!=""}) by (pod, namespace))
```
- [Pods network I/O](<https://grafana.teleport.usummitapp.net/d/jcdpwbcia/kubernetes-cluster-overall-dashboard?orgId=1&refresh=5s&editPanel=16>)

**A**
```bash
sum (rate (container_network_receive_bytes_total{image!="",name=~"^k8s_.*"}[5m])) by (pod_name)
```
to
```bash
sort_desc (sum (rate (container_network_receive_bytes_total{image!=""}[5m])) by (pod, namespace))
```
**B**
```bash
- sum (rate (container_network_transmit_bytes_total{image!="",name=~"^k8s_.*"}[5m])) by (pod_name)
```
to
```bash
sort_desc (- sum (rate (container_network_transmit_bytes_total{image!=""}[5m])) by (pod, namespace))
```